### PR TITLE
fix nf_elem_print_pretty

### DIFF
--- a/nf_elem/print_pretty.c
+++ b/nf_elem/print_pretty.c
@@ -61,9 +61,6 @@ void nf_elem_print_pretty(const nf_elem_t a, const nf_t nf, const char * var)
 		   flint_printf("/");
 		   fmpz_print(aden);
 		}
-    } else if (nf->flag & NF_MONIC)
-    {
-       _fmpz_poly_fprint_pretty(stdout, NF_ELEM_NUMREF(a), NF_ELEM(a)->length, var);
     } else
     {
         fmpq_poly_print_pretty(NF_ELEM(a), var);


### PR DESCRIPTION
The monicity of the polynomial should not influence the appearance of denominator! One might have check whether the denominator is one but this case is already taken care in fmpq_poly_print_pretty.
