### PR TITLE
Fix a bug in multiplication

### DIFF
--- a/nf_elem/mul.c
+++ b/nf_elem/mul.c
@@ -74,6 +74,8 @@ void _nf_elem_mul_red(nf_elem_t a, const nf_elem_t b,
 
             _fmpz_vec_clear(prod, 3);
          }
+
+         fmpz_zero(anum + 2);
       }
    } else /* generic nf_elem */
    {


### PR DESCRIPTION
I got nonreduced results from calling ordinary multiplication on elements in quadratic number fields.

I think we compute `(b0 + b1*x)/bden * (c0 + c1*x)/cden` as `(b0*c0 + (b1*c0 + b0*c1)*x + b1*c1 x^2)/(bden*cden)`. Then for the reduction, if the defining polynomial is denoted by `x^2 + A*x + B`, we subtract `(b1*c1)/(bden*cden) * (A*x + B)` from `(b0*c0 + (b1*c0 + b0*c1)*x)/(bden*cden)`. I think we have to manually set the third coefficient to zero, since we are being clever with reduction. Does this make sense?

A second thing I noticed is that the nonmonic case is not handled. I think both cases in https://github.com/fieker/antic/blob/235b10a1b5212792e5a15e877ccc5c08c3885d83/nf_elem/mul.c#L63-L76 are the same. The denominator of the defining polynomial is never touched here.