### PR TITLE
proper build system for antic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+libantic*
+Makefile
+build/

--- a/INSTALL
+++ b/INSTALL
@@ -1,15 +1,11 @@
 Instructions on installing ant
 ------------------------------
 
-If /path/to/ant is the top level directory of ANT then pass the following to flint2 configure (along with the usual options for your system):
+ANTIC follows a standard installation format for installation
 
-./configure --extensions=/path/to/ant
-
-Then as usual, the following ought to work:
-
+./configure
 make
 make check
 make install
 
-For further information refer to the flint2 documentation (see http://flintlib.org)
-
+Note that ANTIC needs flint (see http://flintlib.org).

--- a/Makefile.in
+++ b/Makefile.in
@@ -163,7 +163,7 @@ endif
 
 install: library
 	mkdir -p $(DESTDIR)$(PREFIX)/$(LIBDIR)
-	mkdir -p $(DESTDIR)$(PREFIX)/include
+	mkdir -p $(DESTDIR)$(PREFIX)/include/antic
 	$(AT)if [ "$(ANTIC_SHARED)" -eq "1" ]; then \
 		cp $(ANTIC_LIB) "$(DESTDIR)$(PREFIX)/$(LIBDIR)"; \
 		cp -a $(shell ls $(ANTIC_LIBNAME)*) "$(DESTDIR)$(PREFIX)/$(LIBDIR)"; \
@@ -171,9 +171,9 @@ install: library
 	$(AT)if [ "$(ANTIC_STATIC)" -eq "1" ]; then \
 		cp libantic.a $(DESTDIR)$(PREFIX)/$(LIBDIR); \
 	fi
-	cp $(HEADERS) $(DESTDIR)$(PREFIX)/include
+	cp $(HEADERS) $(DESTDIR)$(PREFIX)/include/antic
 	$(AT)if [ ! -z $(EXT_HEADERS) ]; then \
-		cp $(EXT_HEADERS) $(DESTDIR)$(PREFIX)/include; \
+		cp $(EXT_HEADERS) $(DESTDIR)$(PREFIX)/include/antic; \
 	fi
 
 build:

--- a/Makefile.in
+++ b/Makefile.in
@@ -1,0 +1,201 @@
+ifdef $(DLPATH)
+  $(DLPATH):=$($(DLPATH)):$(DLPATH_ADD)
+else
+  $(DLPATH):=$(DLPATH_ADD)
+endif
+
+LIBDIR=lib
+
+QUIET_CC  = @echo '   ' CC  ' ' $@;
+QUIET_CXX = @echo '   ' CXX ' ' $@;
+QUIET_AR  = @echo '   ' AR  ' ' $@;
+
+AT=@
+
+BUILD_DIRS = nf nf_elem qfb \
+   $(EXTRA_BUILD_DIRS)
+
+TEMPLATE_DIRS = 
+
+export
+
+SOURCES = 
+LIB_SOURCES = $(wildcard $(patsubst %, %/*.c, $(BUILD_DIRS)))  $(patsubst %, %/*.c, $(TEMPLATE_DIRS))
+
+HEADERS = $(patsubst %, %.h, $(BUILD_DIRS))
+
+OBJS = $(patsubst %.c, build/%.o, $(SOURCES))
+LIB_OBJS = $(patsubst %, build/%/*.o, $(BUILD_DIRS))
+
+LOBJS = $(patsubst %.c, build/%.lo, $(SOURCES))
+LIB_LOBJS = $(patsubst %, build/%/*.lo, $(BUILD_DIRS))
+MOD_LOBJS = $(patsubst %, build/%.lo, $(BUILD_DIRS))
+
+EXMP_SOURCES = $(wildcard examples/*.c)
+EXMPS = $(patsubst %.c, %, $(EXMP_SOURCES))
+
+TEST_SOURCES = $(wildcard test/*.c)
+TESTS = $(patsubst %.c, build/%$(EXEEXT), $(TEST_SOURCES))
+
+PROF_SOURCES = $(wildcard profile/*.c)
+PROFS = $(patsubst %.c, %$(EXEEXT), $(PROF_SOURCES))
+
+TUNE_SOURCES = $(wildcard tune/*.c)
+TUNE = $(patsubst %.c, %$(EXEEXT), $(TUNE_SOURCES))
+
+EXT_SOURCES = $(foreach ext, $(EXTENSIONS), $(foreach dir, $(patsubst $(ext)/%.h, %, $(wildcard $(ext)/*.h)), $(wildcard $(ext)/$(dir)/*.c)))
+EXT_TEST_SOURCES = $(foreach ext, $(EXTENSIONS), $(foreach dir, $(patsubst $(ext)/%.h, %, $(wildcard $(ext)/*.h)), $(wildcard $(ext)/$(dir)/test/t-*.c)))
+EXT_TUNE_SOURCES = $(foreach ext, $(EXTENSIONS), $(foreach dir, $(patsubst $(ext)/%.h, %, $(wildcard $(ext)/*.h)), $(wildcard $(ext)/$(dir)/tune/*.c)))
+EXT_PROF_SOURCES = $(foreach ext, $(EXTENSIONS), $(foreach dir, $(patsubst $(ext)/%.h, %, $(wildcard $(ext)/*.h)), $(wildcard $(ext)/$(dir)/profile/p-*.c)))
+EXT_OBJS = $(foreach ext, $(EXTENSIONS), $(foreach dir, $(patsubst $(ext)/%.h, %, $(wildcard $(ext)/*.h)), build/$(dir).lo))
+EXT_HEADERS = $(foreach ext, $(EXTENSIONS), $(wildcard $(ext)/*.h))
+
+all: library
+
+quiet: library
+
+verbose:
+	$(MAKE) AT= QUIET_CC= QUIET_CXX= QUIET_AR=
+
+clean:
+	$(AT)$(foreach dir, $(BUILD_DIRS), BUILD_DIR=../build/$(dir); export BUILD_DIR; MOD_DIR=$(dir); export MOD_DIR; $(MAKE) -f ../Makefile.subdirs -C $(dir) clean || exit $$?;)
+	$(AT)$(foreach ext, $(EXTENSIONS), $(foreach dir, $(patsubst $(ext)/%.h, %, $(wildcard $(ext)/*.h)), BUILD_DIR=$(CURDIR)/build/$(dir); export BUILD_DIR; MOD_DIR=$(dir); export MOD_DIR; $(MAKE) -f $(CURDIR)/Makefile.subdirs -C $(ext)/$(dir) clean || exit $$?;))
+	rm -f $(OBJS) $(LOBJS) $(TESTS) $(PROFS) $(EXMPS) $(wildcard $(ANTIC_LIBNAME)*) libantic.a
+	rm -rf build
+
+distclean: clean
+	rm -f Makefile
+
+profile: library $(PROF_SOURCES) $(EXT_PROF_SOURCES) build/profiler.o
+	mkdir -p build/profile
+ifndef MOD
+	$(AT)$(foreach prog, $(PROFS), $(CC) $(ABI_FLAG) -std=c99 -O2 -g $(INCS) $(prog).c build/profiler.o -o build/$(prog) $(LIBS) || exit $$?;)
+	$(AT)$(foreach dir, $(BUILD_DIRS), mkdir -p build/$(dir)/profile; BUILD_DIR=../build/$(dir); export BUILD_DIR; $(MAKE) -f ../Makefile.subdirs -C $(dir) profile || exit $$?;)
+	$(AT)$(foreach ext, $(EXTENSIONS), $(foreach dir, $(patsubst $(ext)/%.h, %, $(wildcard $(ext)/*.h)), mkdir -p build/$(dir)/profile; BUILD_DIR=$(CURDIR)/build/$(dir); export BUILD_DIR; MOD_DIR=$(dir); export MOD_DIR; $(MAKE) -f $(CURDIR)/Makefile.subdirs -C $(ext)/$(dir) profile || exit $$?;))
+else
+	$(AT)$(foreach dir, $(MOD), mkdir -p build/$(dir)/profile; BUILD_DIR=../build/$(dir); export BUILD_DIR; $(MAKE) -f ../Makefile.subdirs -C $(dir) profile || exit $$?;)
+endif
+
+tune: library $(TUNE_SOURCES) $(EXT_TUNE_SOURCES)
+	mkdir -p build/tune
+	$(AT)$(foreach prog, $(TUNE), $(CC) $(CFLAGS) $(INCS) $(prog).c -o build/$(prog) $(LIBS) || exit $$?;)
+	$(AT)$(foreach dir, $(BUILD_DIRS), mkdir -p build/$(dir)/tune; BUILD_DIR=../build/$(dir); export BUILD_DIR; $(MAKE) -f ../Makefile.subdirs -C $(dir) tune || exit $$?;)
+	$(AT)$(foreach ext, $(EXTENSIONS), $(foreach dir, $(patsubst $(ext)/%.h, %, $(wildcard $(ext)/*.h)), mkdir -p build/$(dir)/tune; BUILD_DIR=$(CURDIR)/build/$(dir); export BUILD_DIR; MOD_DIR=$(dir); export MOD_DIR; $(MAKE) -f $(CURDIR)/Makefile.subdirs -C $(ext)/$(dir) tune || exit $$?;))
+
+examples: library $(EXMP_SOURCES)
+	mkdir -p build/examples
+	$(AT)$(foreach prog, $(EXMPS), $(CC) $(CFLAGS) $(INCS) $(prog).c -o build/$(prog) $(LIBS) || exit $$?;)
+
+$(ANTIC_LIB): $(LOBJS) $(LIB_SOURCES) $(EXT_SOURCES) $(HEADERS) $(EXT_HEADERS) | build build/interfaces
+	$(AT)$(foreach ext, $(EXTENSIONS), $(foreach dir, $(patsubst $(ext)/%.h, %, $(wildcard $(ext)/*.h)), mkdir -p build/$(dir); BUILD_DIR=$(CURDIR)/build/$(dir); export BUILD_DIR; MOD_DIR=$(dir); export MOD_DIR; $(MAKE) -f $(CURDIR)/Makefile.subdirs -C $(ext)/$(dir) shared || exit $$?;))
+	$(AT)$(foreach dir, $(BUILD_DIRS), mkdir -p build/$(dir); BUILD_DIR=../build/$(dir); export BUILD_DIR; MOD_DIR=$(dir); export MOD_DIR; $(MAKE) -f ../Makefile.subdirs -C $(dir) shared || exit $$?;)
+	$(AT)if [ "$(WANT_NTL)" -eq "1" ]; then \
+	  $(MAKE) build/interfaces/NTL-interface.lo; \
+	  $(CXX) $(ABI_FLAG) -shared $(EXTRA_SHARED_FLAGS) build/interfaces/NTL-interface.lo $(LOBJS) $(MOD_LOBJS) $(EXT_OBJS) -o $(ANTIC_LIB) $(LDFLAGS) $(LIBS2); \
+	fi
+	$(AT)if [ "$(WANT_NTL)" -ne "1" ]; then \
+	  $(CC) $(ABI_FLAG) -shared $(EXTRA_SHARED_FLAGS) $(LOBJS) $(MOD_LOBJS) $(EXT_OBJS) -o $(ANTIC_LIB) $(LDFLAGS) $(LIBS2); \
+	fi
+	-$(AT)if [ "$(ANTIC_SOLIB)" -eq "1" ]; then \
+		$(LDCONFIG) -n "$(CURDIR)"; \
+	fi
+	ln -sf "$(ANTIC_LIB)" "$(ANTIC_LIBNAME)"; \
+	ln -sf "$(ANTIC_LIB)" "$(ANTIC_LIBNAME).$(ANTIC_MAJOR)"; \
+
+libantic.a: $(OBJS) $(LIB_SOURCES) $(EXT_SOURCES) $(HEADERS) $(EXT_HEADERS) | build build/interfaces
+	$(AT)$(foreach ext, $(EXTENSIONS), $(foreach dir, $(patsubst $(ext)/%.h, %, $(wildcard $(ext)/*.h)), mkdir -p build/$(dir); BUILD_DIR=$(CURDIR)/build/$(dir); export BUILD_DIR; MOD_DIR=$(dir); export MOD_DIR; $(MAKE) -f $(CURDIR)/Makefile.subdirs -C $(ext)/$(dir) static || exit $$?;))
+	$(AT)$(foreach dir, $(BUILD_DIRS), mkdir -p build/$(dir); BUILD_DIR=../build/$(dir); export BUILD_DIR; MOD_DIR=$(dir); export MOD_DIR; $(MAKE) -f ../Makefile.subdirs -C $(dir) static || exit $$?;)
+	$(AT)if [ "$(ANTIC_SHARED)" -eq "0" ]; then \
+		touch test/t-*.c; \
+		$(foreach dir, $(BUILD_DIRS), touch $(dir)/test/t-*.c;) \
+		$(foreach ext, $(EXTENSIONS), $(foreach mod, $(patsubst $(ext)/%.h, %, $(wildcard $(ext)/*.h)), touch $(ext)/$(mod)/test/t-*.c;)) \
+	fi
+	$(AT)if [ "$(WANT_NTL)" -eq "1" ]; then \
+		$(MAKE) build/interfaces/NTL-interface.o; \
+		$(AR) rcs libantic.a build/interfaces/NTL-interface.o; \
+	fi
+	$(AT)$(foreach mod, $(BUILD_DIRS), $(AR) rcs libantic.a build/$(mod)/*.o || exit $$?;)
+	$(AT)$(foreach ext, $(EXTENSIONS), $(foreach mod, $(patsubst $(ext)/%.h, %, $(wildcard $(ext)/*.h)), $(AR) rcs libantic.a build/$(mod)/*.o || exit $$?;))
+
+library:
+	$(AT)if [ "$(ANTIC_SHARED)" -eq "1" ]; then \
+		$(MAKE) shared; \
+	fi
+	$(AT)if [ "$(ANTIC_STATIC)" -eq "1" ]; then \
+		$(MAKE) static; \
+	fi
+
+shared: $(ANTIC_LIB)
+
+static: libantic.a
+
+tests: library $(TESTS)
+	$(AT)$(foreach dir, $(BUILD_DIRS), mkdir -p build/$(dir)/test; BUILD_DIR=../build/$(dir); export BUILD_DIR; $(MAKE) -f ../Makefile.subdirs -C $(dir) tests || exit $$?;)
+	$(AT)$(foreach ext, $(EXTENSIONS), $(foreach dir, $(patsubst $(ext)/%.h, %, $(wildcard $(ext)/*.h)), mkdir -p build/$(dir)/test; BUILD_DIR=$(CURDIR)/build/$(dir); export BUILD_DIR; MOD_DIR=$(dir); export MOD_DIR; $(MAKE) -f $(CURDIR)/Makefile.subdirs -C $(ext)/$(dir) tests || exit $$?;))
+	mkdir -p build/interfaces/test
+	$(AT)if [ "$(WANT_NTL)" -eq "1" ]; then \
+		$(MAKE) build/interfaces/test/t-NTL-interface; \
+	fi
+
+check: library
+ifndef MOD
+	$(AT)$(MAKE) $(TESTS)
+	$(AT)$(foreach prog, $(TESTS), $(prog) || exit $$?;)
+	$(AT)$(foreach ext, $(EXTENSIONS), $(foreach dir, $(patsubst $(ext)/%.h, %, $(wildcard $(ext)/*.h)), mkdir -p build/$(dir)/test; BUILD_DIR=$(CURDIR)/build/$(dir); export BUILD_DIR; MOD_DIR=$(dir); export MOD_DIR; $(MAKE) -f $(CURDIR)/Makefile.subdirs -C $(ext)/$(dir) check || exit $$?;))
+	$(AT)$(foreach dir, $(BUILD_DIRS), mkdir -p build/$(dir)/test; BUILD_DIR=../build/$(dir); export BUILD_DIR; $(MAKE) -f ../Makefile.subdirs -C $(dir) check || exit $$?;)
+	mkdir -p build/interfaces/test
+	$(AT)if [ "$(WANT_NTL)" -eq "1" ]; then \
+		$(MAKE) build/interfaces/test/t-NTL-interface; \
+		build/interfaces/test/t-NTL-interface; \
+	fi
+else
+	$(AT)$(foreach dir, $(MOD), test ! -d $(dir) || mkdir -p build/$(dir)/test; BUILD_DIR=../build/$(dir); export BUILD_DIR; test ! -d $(dir) || $(MAKE) -f ../Makefile.subdirs -C $(dir) check || exit $$?;)
+	$(AT)$(foreach ext, $(EXTENSIONS), $(AT)$(foreach dir, $(MOD), MOD_DIR=$(dir); export MOD_DIR; test ! -d $(ext)/$(dir) || mkdir -p build/$(dir)/test; BUILD_DIR=$(CURDIR)/build/$(dir); export BUILD_DIR; test ! -d $(ext)/$(dir) || $(MAKE) -f $(CURDIR)/Makefile.subdirs -C $(ext)/$(dir) check || exit $$?;))
+endif
+
+valgrind: library
+ifndef MOD
+	$(AT)$(foreach dir, $(BUILD_DIRS), mkdir -p build/$(dir)/test; BUILD_DIR=../build/$(dir); export BUILD_DIR; $(MAKE) -f ../Makefile.subdirs -C $(dir) valgrind || exit $$?;)
+	$(AT)$(foreach ext, $(EXTENSIONS), $(foreach dir, $(patsubst $(ext)/%.h, %, $(wildcard $(ext)/*.h)), mkdir -p build/$(dir)/test; BUILD_DIR=$(CURDIR)/build/$(dir); export BUILD_DIR; MOD_DIR=$(dir); export MOD_DIR; $(MAKE) -f $(CURDIR)/Makefile.subdirs -C $(ext)/$(dir) valgrind || exit $$?;))
+else
+	$(AT)$(foreach dir, $(MOD), mkdir -p build/$(dir)/test; BUILD_DIR=../build/$(dir); export BUILD_DIR; $(MAKE) -f ../Makefile.subdirs -C $(dir) valgrind || exit $$?;)
+endif
+
+install: library
+	mkdir -p $(DESTDIR)$(PREFIX)/$(LIBDIR)
+	mkdir -p $(DESTDIR)$(PREFIX)/include
+	$(AT)if [ "$(ANTIC_SHARED)" -eq "1" ]; then \
+		cp $(ANTIC_LIB) "$(DESTDIR)$(PREFIX)/$(LIBDIR)"; \
+		cp -a $(shell ls $(ANTIC_LIBNAME)*) "$(DESTDIR)$(PREFIX)/$(LIBDIR)"; \
+	fi
+	$(AT)if [ "$(ANTIC_STATIC)" -eq "1" ]; then \
+		cp libantic.a $(DESTDIR)$(PREFIX)/$(LIBDIR); \
+	fi
+	cp $(HEADERS) $(DESTDIR)$(PREFIX)/include
+	$(AT)if [ ! -z $(EXT_HEADERS) ]; then \
+		cp $(EXT_HEADERS) $(DESTDIR)$(PREFIX)/include; \
+	fi
+
+build:
+	mkdir -p build
+
+build/%.lo: %.c $(HEADERS) | build
+	$(QUIET_CC) $(CC) $(PIC_FLAG) $(CFLAGS) $(INCS) -c $< -o $@;
+
+build/%.o: %.c $(HEADERS) | build
+	$(QUIET_CC) $(CC) $(CFLAGS) $(INCS) -c $< -o $@;
+
+build/test/%$(EXEEXT): test/%.c $(HEADERS) | build/test
+	$(QUIET_CC) $(CC) $(CFLAGS) $(INCS) $< -o $@ $(LIBS)
+
+build/test:
+	mkdir -p build/test
+
+build/interfaces:
+	mkdir -p build/interfaces
+
+print-%:
+	@echo '$*=$($*)'
+
+.PHONY: profile library shared static clean examples tune check tests distclean dist install all valgrind
+

--- a/Makefile.subdirs
+++ b/Makefile.subdirs
@@ -1,0 +1,89 @@
+QUIET_CC  = @echo '   ' CC  ' ' $@;
+
+AT=@
+
+SOURCES = $(wildcard *.c)
+
+HEADERS = $(wildcard ../*.h)
+TEST_HEADERS = $(wildcard *.h)
+
+OBJS = $(patsubst %.c, $(BUILD_DIR)/$(MOD_DIR)_%.o, $(SOURCES))
+
+LOBJS = $(patsubst %.c, $(BUILD_DIR)/%.lo, $(SOURCES))
+MOD_LOBJ = $(BUILD_DIR)/../$(MOD_DIR).lo
+
+TEST_SOURCES = $(wildcard test/*.c)
+TESTXX_SOURCES = $(wildcard test/*.cpp)
+
+PROF_SOURCES = $(wildcard profile/*.c)
+
+TUNE_SOURCES = $(wildcard tune/*.c)
+
+TESTS = $(patsubst %.c, $(BUILD_DIR)/%$(EXEEXT), $(TEST_SOURCES)) \
+        $(patsubst %.cpp, $(BUILD_DIR)/%$(EXEEXT), $(TESTXX_SOURCES))
+
+TESTS_RUN = $(patsubst %, %_RUN, $(TESTS))
+
+VALGRIND_RUN = $(patsubst %, %_VALGRIND_RUN, $(TESTS))
+
+PROFS = $(patsubst %.c, $(BUILD_DIR)/%$(EXEEXT), $(PROF_SOURCES))
+
+TUNE = $(patsubst %.c, %$(EXEEXT), $(TUNE_SOURCES))
+
+all: shared static
+
+shared: $(MOD_LOBJ)
+
+static: $(OBJS)
+
+profile: $(PROFS)
+
+-include $(patsubst %, %.d, $(PROFS))
+
+$(BUILD_DIR)/profile/%$(EXEEXT): profile/%.c $(BUILD_DIR)/../profiler.o
+	$(QUIET_CC) $(CC) $(ABI_FLAG) -O2 -std=c99 -g $(INCS) $< $(BUILD_DIR)/../profiler.o -o $@ $(LIBS)  -MMD -MP -MF $@.d -MT "$@" -MT "$@.d"
+
+tune: $(TUNE_SOURCES) $(HEADERS)
+	$(AT)$(foreach prog, $(TUNE), $(CC) $(CFLAGS) $(INCS) $(prog).c -o $(BUILD_DIR)/$(prog) $(LIBS) || exit $$?;)
+
+-include $(OBJS:.o=.d)
+
+$(BUILD_DIR)/$(MOD_DIR)_%.o: %.c
+	$(QUIET_CC) $(CC) $(CFLAGS) $(INCS) -c $< -o $@ -MMD -MP -MF "$(BUILD_DIR)/$(MOD_DIR)_$*.d" -MT "$(BUILD_DIR)/$(MOD_DIR)_$*.d" -MT "$@"
+
+$(MOD_LOBJ): $(LOBJS)
+	$(QUIET_CC) $(CC) $(ABI_FLAG) -r $^ -o $@ -nostdlib
+
+-include $(LOBJS:.lo=.d)
+
+$(BUILD_DIR)/%.lo: %.c
+	$(QUIET_CC) $(CC) $(PIC_FLAG) $(CFLAGS) $(INCS) -c $< -o $@ -MMD -MP -MF "$(BUILD_DIR)/$*.d" -MT "$(BUILD_DIR)/$*.d" -MT "$@"
+
+clean:
+	rm -rf $(BUILD_DIR) $(MOD_LOBJ)
+
+tests: $(TESTS)
+
+check: tests $(TESTS_RUN)
+
+valgrind: tests $(VALGRIND_RUN)
+
+-include $(patsubst %, %.d, $(TESTS))
+
+ifeq ($(ANTIC_SHARED), 0)
+$(BUILD_DIR)/test/%$(EXEEXT): $(BUILD_DIR)/../../libantic.a
+endif
+
+$(BUILD_DIR)/test/%$(EXEEXT): test/%.c
+	$(QUIET_CC) $(CC) $(CFLAGS) $(INCS) $< -o $@ $(LIBS) -MMD -MP -MF $@.d -MT "$@" -MT "$@.d"
+
+$(BUILD_DIR)/test/%$(EXEEXT): test/%.cpp $(BUILD_DIR)/../../test_helpers.o
+	$(QUIET_CC) $(CXX) $(CFLAGS) $(INCS) $< -o $@ $(LIBS) -MMD -MP -MF $@.d -MT "$@" -MT "$@.d"
+
+%_RUN: %
+	@$<
+
+%_VALGRIND_RUN: %
+	valgrind --track-origins=yes --leak-check=full --show-reachable=yes --log-file="$*.valgrind" $<
+
+.PHONY: profile tune clean check tests all shared static valgrind %_RUN %_VALGRIND_RUN

--- a/README
+++ b/README
@@ -5,10 +5,7 @@ Antic is an algebraic number theory library.
 
 The only dependency at present is flint2 (see http://flintlib.org).
 
-To install Antic, clone the repository into a directory on your filesystem, e.g. /home/username/antic
-
-Now build flint in the usual way, passing --extensions=/home/username/antic to flint's configure.
-
-The usual make, make check, make install, make clean, etc. apply.
+To install Antic, clone the repository into a directory on your filesystem,
+e.g. /home/username/antic and follows the instruction in the INSTALL file.
 
 William Hart -- 12 May 2013.

--- a/configure
+++ b/configure
@@ -1,0 +1,640 @@
+#!/bin/sh
+
+# (C) 2007, Robert Bradshaw, William Hart, William Stein, Michael Abshoff
+# (C) 2011, William Hart
+# (C) 2012, William Hart, Jean-Pierre Flori, Thomas DuBuisson
+# (C) 2012, Jan Engelhardt
+# (C) 2017, Vincent Delecroix
+
+# soname version
+#
+# antic   => soname
+# 0.0.1   => 0.0.0
+ANTIC_MAJOR=0
+ANTIC_MINOR=0
+ANTIC_PATCH=1
+
+PREFIX="/usr/local"
+GMP_DIR="/usr/local"
+MPFR_DIR="/usr/local"
+FLINT_DIR="/usr/local"
+NTL_DIR="/usr/local"
+GC_DIR="/usr/local"
+BLAS_DIR="/usr/local"
+WANT_NTL=0
+WANT_BLAS=0
+SHARED=1
+STATIC=1
+TLS=1
+PTHREAD=1
+REENTRANT=0
+WANT_GC=0
+WANT_TLS=0
+WANT_CXX=0
+ASSERT=0
+BUILD=
+EXTENSIONS=
+EXT_MODS=
+EXTRA_BUILD=
+
+usage()
+{
+   echo "Usage: ./configure <options> <args>"
+   echo "   where <options> may be"
+   echo "     -h display usage information"
+   echo "   where <args> may be:"
+   echo "     --prefix=<path>      Specify path to installation location (default: /usr/local)"
+   echo "     --with-mpir=<path>   Specify location of MPIR (default: /usr/local)"
+   echo "     --with-gmp=<path>    Specify location of GMP (default: /usr/local)"
+   echo "     --with-mpfr=<path>   Specify location of MPFR (default: /usr/local)"
+   echo "     --with-flint=<path>  Specify location of FLINT (default: /usr/local)"
+   echo "     --extensions=<path>  Specify location of extension modules"
+   echo "     --build=arch-os      Specify architecture/OS combination rather than use values from uname -m/-s"
+   echo "     --enable-shared      Build a shared library (default)"
+   echo "     --disable-shared     Do not build a shared library"
+   echo "     --enable-static      Build a static library (default)"
+   echo "     --disable-static     Do not build a static library"
+   echo "     --single             Faster [non-reentrant if tls or pthread not used] version of library (default)"
+   echo "     --reentrant          Build fully reentrant [with or without tls, with pthread] version of library"
+   echo "     --with-gc=<path>     GC safe build with path to gc"
+   echo "     --enable-pthread     Use pthread (default)"
+   echo "     --disable-pthread    Do not use pthread"
+   echo "     --enable-tls         Use thread-local storage (default)"
+   echo "     --disable-tls        Do not use thread-local storage"
+   echo "     --enable-assert      Enable use of asserts (use for debug builds only)"
+   echo "     --disable-assert     Disable use of asserts (default)"
+   echo "     --enable-cxx         Enable C++ wrapper tests"
+   echo "     --disable-cxx        Disable C++ wrapper tests (default)"
+   echo "     CC=<name>            Use the C compiler with the given name (default: gcc)"
+   echo "     CXX=<name>           Use the C++ compiler with the given name (default: g++)"
+   echo "     AR=<name>            Use the AR library builder with the given name (default: ar)"
+   echo "     CFLAGS=<flags>       Pass the given flags to the compiler"
+   echo "     ABI=[32|64]          Tell the compiler to use given ABI (default: empty)"
+}
+
+
+absolute_path(){
+   dirlist="$1"
+   retval=""
+   for dir in $dirlist; do
+      case $dir in
+        /*) dir=$dir;;
+        *) dir=$PWD/$dir;;
+      esac
+      retval=$retval" "$dir
+   done
+   echo $retval
+}
+
+while [ "$1" != "" ]; do
+   PARAM=`echo $1 | sed 's/=.*//'`
+   VALUE=`echo $1 | sed 's/[^=]*//; s/=//'`
+   case "$PARAM" in
+      -h|--help)
+         usage
+         exit 0
+         ;;
+      --with-mpir|--with-gmp)
+         GMP_DIR=$(absolute_path "$VALUE")
+         ;;
+      --with-mpfr)
+         MPFR_DIR=$(absolute_path "$VALUE")
+         ;;
+      --with-flint)
+         FLINT_DIR=$(absolute_path "$VALUE")
+         ;;
+      --extensions)
+         EXTENSIONS=$(absolute_path "$VALUE")
+         ;;
+      --build)
+         BUILD="$VALUE"
+         ;;
+      --prefix)
+         PREFIX=$VALUE
+         ;;
+      --enable-shared)
+         SHARED=1
+         ;;
+      --disable-shared)
+         SHARED=0
+         ;;
+      --enable-static)
+         STATIC=1
+         ;;
+      --disable-static)
+         STATIC=0
+         ;;
+      --single)
+         REENTRANT=0
+         ;;
+      --reentrant)
+         REENTRANT=1
+         ;;
+      --with-gc)
+	 WANT_GC=1
+         if [ ! -z "$VALUE" ]; then
+            GC_DIR="$VALUE"
+         fi
+         ;;
+      --enable-pthread)
+         PTHREAD=1
+         ;;
+      --disable-pthread)
+         PTHREAD=0
+         ;;
+      --enable-tls)
+         TLS=1
+         WANT_TLS=1;;
+      --disable-tls)
+         TLS=0
+         ;;
+      --enable-assert)
+         ASSERT=1
+         ;;
+      --disable-assert)
+         ASSERT=0
+         ;;
+      --enable-cxx)
+         WANT_CXX=1
+         ;;
+      --disable-cxx)
+         WANT_CXX=0
+         ;;
+      AR)
+         AR="$VALUE"
+         ;;
+      CC)
+         CC="$VALUE"
+         ;;
+      CXX)
+         CXX="$VALUE"
+         ;;
+      CFLAGS)
+         CFLAGS="$VALUE"
+         ;;
+      ABI)
+         ABI="$VALUE"
+         ;;
+      *)
+         usage
+         exit 1
+         ;;
+   esac
+   shift
+done
+
+#find dependencies
+
+LIBS="m"
+
+if [ -d "${GMP_DIR}/lib" ]; then
+   GMP_LIB_DIR="${GMP_DIR}/lib"
+   GMP_INC_DIR="${GMP_DIR}/include"
+elif [ -d "${GMP_DIR}/lib64" ]; then
+   GMP_LIB_DIR="${GMP_DIR}/lib64"
+   GMP_INC_DIR="${GMP_DIR}/include"
+elif [ -d "${GMP_DIR}/.libs" ]; then
+   GMP_LIB_DIR="${GMP_DIR}/.libs"
+   GMP_INC_DIR="${GMP_DIR}"
+else
+   echo "Invalid GMP directory"
+   exit 1
+fi
+LIB_DIRS="${LIB_DIRS} ${GMP_LIB_DIR}"
+INC_DIRS="${INC_DIRS} ${GMP_INC_DIR}"
+LIBS="${LIBS} gmp"
+
+if [ -d "${MPFR_DIR}/lib" ]; then
+   MPFR_LIB_DIR="${MPFR_DIR}/lib"
+   MPFR_INC_DIR="${MPFR_DIR}/include"
+elif [ -d "${MPFR_DIR}/lib64" ]; then
+   MPFR_LIB_DIR="${MPFR_DIR}/lib64"
+   MPFR_INC_DIR="${MPFR_DIR}/include"
+elif [ -d "${MPFR_DIR}/.libs" ]; then
+   MPFR_LIB_DIR="${MPFR_DIR}/.libs"
+   MPFR_INC_DIR="${MPFR_DIR}"
+elif [ -d "${MPFR_DIR}/src/.libs" ]; then
+   MPFR_LIB_DIR="${MPFR_DIR}/src/.libs"
+   MPFR_INC_DIR="${MPFR_DIR}/src"
+else
+   echo "Invalid MPFR directory"
+   exit 1
+fi
+LIB_DIRS="${LIB_DIRS} ${MPFR_LIB_DIR}"
+INC_DIRS="${INC_DIRS} ${MPFR_INC_DIR}"
+LIBS="${LIBS} mpfr"
+
+if [ -d "${FLINT_DIR}/lib" ]; then
+   FLINT_LIB_DIR="${FLINT_DIR}/lib"
+   FLINT_INC_DIR="${FLINT_DIR}/include"
+elif [ -d "${FLINT_DIR}/lib64" ]; then
+   FLINT_LIB_DIR="${FLINT_DIR}/lib64"
+   FLINT_INC_DIR="${FLINT_DIR}/include"
+elif [ -d "${FLINT_DIR}/.libs" ]; then
+   FLINT_LIB_DIR="${FLINT_DIR}/.libs"
+   FLINT_INC_DIR="${FLINT_DIR}"
+elif [ -d "${FLINT_DIR}" ]; then
+   FLINT_LIB_DIR="${FLINT_DIR}"
+   FLINT_INC_DIR="${FLINT_DIR}"
+else
+   echo "Invalid FLINT directory"
+   exit 1
+fi
+
+if [ -d "${FLINT_INC_DIR}/flint" ]; then
+   FLINT_INC_DIR="${FLINT_INC_DIR}"
+elif [ -f "${FLINT_INC_DIR}/flint.h" ]; then
+   mkdir -p build/include
+   ln -sf ${FLINT_INC_DIR} build/include/flint
+   FLINT_INC_DIR="${PWD}/build/include"
+fi
+
+echo "FLINT_LIB_DIR set to ${FLINT_LIB_DIR}"
+echo "FLINT_INC_DIR set to ${FLINT_INC_DIR}"
+
+LIB_DIRS="${LIB_DIRS} ${FLINT_LIB_DIR}"
+INC_DIRS="${INC_DIRS} ${FLINT_INC_DIR}"
+LIBS="${LIBS} flint"
+
+#configure extra libraries
+
+if [ "$WANT_GC" = "1" ]; then
+   if [ -d "${GC_DIR}" ]; then
+      GC_LIB_DIR="${GC_DIR}/lib"
+      GC_INC_DIR="${GC_DIR}/include"
+   else
+      echo "Invalid GC directory"
+      exit 1
+   fi
+   EXTRA_INC_DIRS="${EXTRA_INC_DIRS} ${GC_INC_DIR}"
+   EXTRA_LIB_DIRS="${EXTRA_LIB_DIRS} ${GC_LIB_DIR}"
+   EXTRA_LIBS="${EXTRA_LIBS} gc"
+fi
+CONFIG_GC="#define HAVE_GC ${WANT_GC}"
+
+# defaults for CC, CXX and AR
+
+if [ -z "$CC" ]; then
+   CC=gcc
+fi
+
+if [ -z "$CXX" ]; then
+   CXX=g++
+fi
+
+if [ -z "$AR" ]; then
+   AR=ar
+fi
+
+# Architecture handler
+
+KERNEL=`uname`
+
+if [ -z "$BUILD" ]; then
+   ARCH=`uname -m`
+
+   if [ "$(uname | cut -d_ -f1)" = "MINGW32" ]; then
+      if [ "$ABI" = "64" ]; then
+         OS="MINGW64"
+      else
+         OS="MINGW32"
+      fi
+   elif [ "$(uname | cut -d_ -f1)" = "CYGWIN" ]; then
+      if [ "$ARCH" = "x86_64" ]; then
+         if [ "$ABI" = "32" ]; then
+            OS="CYGWIN32"
+         else
+            OS="CYGWIN64"
+            ABI="64"
+         fi
+      else
+         OS="CYGWIN32"
+      fi
+   else
+      OS=`uname -s`
+   fi
+else
+   ARCH=`echo "$BUILD" | cut -d- -f1`
+   OS=`echo "$BUILD" | cut -d- -f2`
+fi
+
+case "$ARCH" in
+   x86_64 | amd64)
+      MACHINE="x86_64";;
+   x86 | i*86 | pc)
+      MACHINE="x86";;
+   ia64)
+      MACHINE="ia64";;
+   sparc | sun4*)
+      MACHINE="sparc";;
+   sparc64)
+      MACHINE="sparc64";;
+   ppc64 | powerpc64)
+      MACHINE="ppc64";;
+   ppc | powerpc | [P|p]ower*)
+      MACHINE="ppc";;
+   *)
+      MACHINE="unknown";;
+esac
+
+#ABI flag
+if [ "$ABI" = "32" ]; then
+   ABI_FLAG="-m32"
+   case "$MACHINE" in
+      x86_64)
+         MACHINE="x86";;
+      sparc64)
+         MACHINE="sparc";;
+      ppc64)
+         MACHINE="ppc";;
+      *)
+         ;;
+   esac
+elif [ "$ABI" = "64" ]; then
+   ABI_FLAG="-m64"
+   if [ "$MACHINE" = "sparc" ]; then
+      MACHINE="sparc64"
+   fi
+   if [ "$MACHINE" = "x86" ]; then
+      MACHINE="x86_64"
+   fi
+fi
+
+if [ "$MACHINE" = "sparc" ] || [ "$MACHINE" = "sparc64" ]; then
+   if [ "$CC" = "gcc" ]; then
+      CC="gcc -mno-relax"
+   fi
+fi
+
+echo "Configuring...${MACHINE}-${OS}"
+
+#name for ANTIC shared library
+
+ANTIC_SOLIB=0
+if [ -z "$ANTIC_LIB" ]; then
+   case "$OS" in
+      Darwin)
+         ANTIC_LIBNAME="libantic.dylib"
+	 ANTIC_LIB="libantic-$ANTIC_MAJOR.$ANTIC_MINOR.$ANTIC_PATCH.dylib"
+         EXTRA_SHARED_FLAGS="-install_name $PREFIX/lib/$ANTIC_LIB -compatibility_version $ANTIC_MAJOR.$ANTIC_MINOR -current_version $ANTIC_MAJOR.$ANTIC_MINOR.$ANTIC_PATCH";;
+      CYGWIN* | MINGW*)
+         ANTIC_LIBNAME="libantic.dll"
+	 ANTIC_LIB="libantic-$ANTIC_MAJOR.dll"
+	 EXTRA_SHARED_FLAGS="-static-libgcc -shared -Wl,--export-all-symbols -Wl,-soname,libantic-$ANTIC_MAJOR.dll.$ANTIC_MINOR.$ANTIC_PATCH";;
+      *)
+         ANTIC_LIBNAME="libantic.so"
+	 ANTIC_LIB="libantic.so.$ANTIC_MAJOR.$ANTIC_MINOR.$ANTIC_PATCH"
+	 EXTRA_SHARED_FLAGS="-Wl,-soname,libantic.so.$ANTIC_MAJOR"
+	 ANTIC_SOLIB=1;;
+   esac
+fi
+
+# sometimes LDCONFIG is not to be found in the path. Look at some common places.
+case "$OS" in
+    MINGW*|CYGWIN*|Darwin)
+	LDCONFIG="true";;
+    *)
+	if [ -z "$LDCONFIG" ]; then
+	    LDCONFIG="true"
+	    if [ "$ANTIC_SOLIB" = "1" ]; then
+		if command -v ldconfig > /dev/null; then
+		    LDCONFIG="ldconfig"
+		elif [ -x /sbin/ldconfig ]; then
+		    LDCONFIG="/sbin/ldconfig"
+		fi
+	    fi
+	fi;;
+esac
+
+#extension for executables
+
+if [ -z "$EXEEXT" ]; then
+   case "$OS" in
+      CYGWIN* | MINGW*)
+         EXEEXT=".exe";;
+      *)
+         EXEEXT="";;
+   esac
+fi
+
+#don't build both shared and static lib on MinGW and Cygwin
+
+case "$OS" in
+   CYGWIN* | MINGW*)
+      if [ "$STATIC" = "1" ] && [ "$SHARED" = "1" ]; then
+         echo "Building both static and shared versions of MPIR/GMP on $OS is currently"
+         echo "unsupported, and so is it for MPFR, FLINT and ANTIC."
+         echo "You should pass --disable-shared or --disable-static to configure"
+         echo "depending on the versions of MPIR/GMP, MPFR and FLINT you built."
+         exit 1
+      fi
+      ;;
+   *)
+      ;;
+esac 
+
+#test for popcnt flag and set needed CFLAGS
+
+mkdir -p build
+rm -f build/test-popcnt > /dev/null 2>&1
+MSG="Testing __builtin_popcountl..."
+printf "%s" "$MSG"
+echo "int main(int argc, char ** argv) { 
+#if defined(_WIN64)
+return __builtin_popcountll(argc) == 100;
+#else
+return __builtin_popcountl(argc) == 100;
+#endif 
+}" > build/test-popcnt.c
+$CC build/test-popcnt.c -o ./build/test-popcnt > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+   printf "%s\n" "yes"
+   CONFIG_POPCNT_INTRINSICS="#define POPCNT_INTRINSICS"
+
+   if [ "$MACHINE" = "x86_64" ]; then
+      MSG="Testing native popcount..."
+      printf "%s" "$MSG"
+      touch build/test-popcnt.c
+      rm build/test-popcnt
+      $CC -mpopcnt build/test-popcnt.c -o ./build/test-popcnt > /dev/null 2>&1
+      build/test-popcnt > /dev/null 2>&1
+      if [ $? -eq 0 ]; then
+         printf "%s\n" "yes"
+         POPCNT_FLAG="-mpopcnt"
+      else
+         printf "%s\n" "no"
+      fi
+      rm -f build/test-popcnt{,.c}
+   #in case -mpopcnt is not available, the test program will use an illegal
+   #instruction and that will print out something on stderr when the if
+   #construction is exited, whence the following "2> /dev/null"
+   fi 2> /dev/null
+else
+   rm -f build/test-popcnt.c
+   printf "%s\n" "no"
+fi
+
+#defaults for CFLAGS
+
+if [ -z "$CFLAGS" ]; then
+   if [ "$OS" = "MINGW64" ]; then
+      CFLAGS="-O2 -funroll-loops -g $POPCNT_FLAG $ABI_FLAG"
+   elif [ "$OS" = "CYGWIN64" ]; then
+      CFLAGS="-O2 -funroll-loops -g -D _WIN64 $POPCNT_FLAG $ABI_FLAG"
+   else
+      CFLAGS="-ansi -pedantic -Wall -O2 -funroll-loops -g $POPCNT_FLAG $ABI_FLAG"
+   fi
+fi
+
+#this is needed on PPC G5 and does not hurt on other OS Xes
+
+if [ "$KERNEL" = Darwin ]; then
+   CFLAGS="-fno-common $CFLAGS"
+fi
+
+#PIC flag
+
+if [ -z "$PIC_FLAG" ]; then
+   case "$OS" in
+      CYGWIN* | MINGW*)
+         ;;
+      *)
+         PIC_FLAG="-fPIC";;
+   esac
+fi
+
+#test support for thread-local storage
+
+CONFIG_TLS="#define HAVE_TLS 0"
+
+if [ "$TLS" = "1" ]; then
+   mkdir -p build
+   rm -f build/test-tls > /dev/null 2>&1
+   MSG="Testing __thread..."
+   printf "%s" "$MSG"
+   echo "__thread int x = 42; int main(int argc, char ** argv) { return x != 42; }" > build/test-tls.c
+   $CC build/test-tls.c -o ./build/test-tls > /dev/null 2>&1
+   if [ $? -eq 0 ]; then
+      build/test-tls > /dev/null 2>&1
+      if [ $? -eq 0 ]; then
+         printf "%s\n" "yes"
+         CONFIG_TLS="#define HAVE_TLS 1"
+      else
+         printf "%s\n" "no"
+      fi
+      rm -f build/test-tls{,.c}
+   else
+      rm -f build/test-tls.c
+      printf "%s\n" "no"
+   #build-tls can segfault on systems where tls is not available
+   fi 2> /dev/null
+fi
+
+#pthread configuration
+
+CONFIG_PTHREAD="#define HAVE_PTHREAD ${PTHREAD}"
+
+
+#pocess external modules
+
+EXTRA_INC_DIRS="${EXTRA_INC_DIRS} ${EXTENSIONS}"
+
+
+if [ -d "${EXTENSIONS}/examples" ]; then
+   cp ${EXTENSIONS}/examples/*.c ./examples/
+fi
+
+#include paths
+
+INCS="-I\$(CURDIR)"
+for INC_DIR in ${INC_DIRS} ${EXTRA_INC_DIRS}; do
+   INCS="${INCS} -I${INC_DIR}"
+done
+
+#library paths
+
+LLIBS="-L\$(CURDIR)"
+for LIB_DIR in ${LIB_DIRS} ${EXTRA_LIB_DIRS}; do
+   LLIBS="${LLIBS} -L${LIB_DIR}"
+done
+
+#linker params
+
+if [ "$PTHREAD" = "1" ]; then
+   lLIBS2="-lpthread ${lLIBS2}"
+fi
+
+
+for LIB in ${EXTRA_LIBS} ${LIBS}; do
+   lLIBS2="-l${LIB} ${lLIBS2}"
+done
+lLIBS="-lantic $lLIBS2"
+LIBS2="$LLIBS $lLIBS2"
+LIBS="$LLIBS $lLIBS"
+
+#paths for dynamic linker
+
+case "$OS" in
+   CYGWIN* | MINGW*)
+      DLPATH="PATH";;
+   Darwin)
+      DLPATH="DYLD_LIBRARY_PATH";;
+   sparc)
+      DLPATH="LD_LIBRARY_PATH32";;
+   sparc64)
+      DLPATH="LD_LIBRARY_PATH64";;
+   *)
+      DLPATH="LD_LIBRARY_PATH";;
+esac
+
+DLPATH_ADD="\$(CURDIR)"
+for LIB_DIR in ${LIB_DIRS} ${EXTRA_LIB_DIRS}; do
+   DLPATH_ADD="${DLPATH_ADD}:${LIB_DIR}"
+done
+
+#cxx
+
+if [ "$WANT_CXX" = "1" ]; then
+   EXTRA_BUILD="$EXTRA_BUILD anticxx"
+fi
+
+#write out Makefile
+
+echo "# This file is autogenerated by ./configure -- do not edit!" > Makefile
+echo "" >> Makefile
+echo "SHELL=/bin/sh" >> Makefile
+echo "" >> Makefile
+echo "ANTIC_STATIC=$STATIC" >> Makefile
+echo "ANTIC_SHARED=$SHARED" >> Makefile
+echo "ANTIC_LIB=$ANTIC_LIB" >> Makefile
+echo "ANTIC_LIBNAME=$ANTIC_LIBNAME" >> Makefile
+echo "ANTIC_MAJOR=$ANTIC_MAJOR" >> Makefile
+echo "ANTIC_SOLIB=$ANTIC_SOLIB" >> Makefile
+echo "EXEEXT=$EXEEXT" >> Makefile
+echo "PREFIX=$PREFIX" >> Makefile
+echo "" >> Makefile
+echo "WANT_NTL=$WANT_NTL" >> Makefile
+echo "" >> Makefile
+echo "INCS=$INCS" >> Makefile
+echo "LIBS=$LIBS" >> Makefile
+echo "LIBS2=$LIBS2" >> Makefile
+echo "" >> Makefile
+echo "CC=$CC" >> Makefile
+echo "CXX=$CXX" >> Makefile
+echo "AR=$AR" >> Makefile
+echo "LDCONFIG=$LDCONFIG" >> Makefile
+echo "" >> Makefile
+echo "CFLAGS=$CFLAGS" >> Makefile
+echo "ABI_FLAG=$ABI_FLAG" >> Makefile
+echo "PIC_FLAG=$PIC_FLAG" >> Makefile
+echo "EXTRA_SHARED_FLAGS=$EXTRA_SHARED_FLAGS" >> Makefile
+echo "" >> Makefile
+echo "DLPATH=$DLPATH" >> Makefile
+echo "DLPATH_ADD=$DLPATH_ADD" >> Makefile
+echo "EXTENSIONS=$EXTENSIONS" >> Makefile
+echo "EXTRA_BUILD_DIRS=$EXTRA_BUILD" >> Makefile
+echo "" >> Makefile
+
+cat Makefile.in >> Makefile
+
+echo "ANTIC was successfully configured."

--- a/nf.h
+++ b/nf.h
@@ -27,14 +27,16 @@
 #define NF_H
 
 #include "gmp.h"
-#include "flint.h"
-#include "fmpz.h"
-#include "fmpz_poly.h"
-#include "fmpq_poly.h"
+#include "flint/flint.h"
+#include "flint/fmpz.h"
+#include "flint/fmpz_poly.h"
+#include "flint/fmpq_poly.h"
 
 #ifdef __cplusplus
  extern "C" {
 #endif
+
+long int antic_test_multiplier();
 
 typedef struct {
    fmpq_poly_t pol;  /* defining polynomial */

--- a/nf/test/t-init_clear.c
+++ b/nf/test/t-init_clear.c
@@ -24,12 +24,7 @@
 ******************************************************************************/
 
 #include <stdio.h>
-#include <gmp.h>
-#include "flint.h"
-#include "fmpz.h"
-#include "fmpz_poly.h"
 #include "nf.h"
-#include "ulong_extras.h"
 
 int
 main(void)
@@ -42,7 +37,7 @@ main(void)
 
     flint_randinit(state);
 
-    for (i = 0; i < 1000 * flint_test_multiplier(); i++)
+    for (i = 0; i < 1000 * antic_test_multiplier(); i++)
     {
         fmpq_poly_t pol;
         nf_t nf;

--- a/nf/test_multiplier.c
+++ b/nf/test_multiplier.c
@@ -1,0 +1,37 @@
+/*
+    Copyright (C) 2016 Fredrik Johansson
+
+    This file is part of Arb.
+
+    Arb is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version.  See <http://www.gnu.org/licenses/>.
+*/
+
+#include <stdlib.h>
+#include "nf.h"
+
+long int _antic_test_multiplier = -1;
+
+long int antic_test_multiplier()
+{
+    if (_antic_test_multiplier == -1)
+    {
+        const char * s = getenv("ANTIC_TEST_MULTIPLIER");
+
+        if (s == NULL)
+        {
+            _antic_test_multiplier = 1;
+        }
+        else
+        {
+            _antic_test_multiplier = strtol(s, NULL, 10);
+
+            if (!(_antic_test_multiplier >= 0.0 && _antic_test_multiplier <= 1000))
+                _antic_test_multiplier = 1;
+        }
+    }
+
+    return _antic_test_multiplier;
+}

--- a/nf_elem.h
+++ b/nf_elem.h
@@ -33,10 +33,10 @@
 #endif
 
 #include "gmp.h"
-#include "flint.h"
-#include "fmpq_poly.h"
-#include "fmpq_mat.h"
-#include "fmpz_mat.h"
+#include "flint/flint.h"
+#include "flint/fmpq_poly.h"
+#include "flint/fmpq_mat.h"
+#include "flint/fmpz_mat.h"
 #include "nf.h"
 
 #ifdef __cplusplus

--- a/nf_elem/norm.c
+++ b/nf_elem/norm.c
@@ -23,7 +23,7 @@
 
 ******************************************************************************/
 
-#include "fmpq.h"
+#include "flint/fmpq.h"
 #include "nf_elem.h"
 
 void _nf_elem_norm(fmpz_t rnum, fmpz_t rden, const nf_elem_t a, const nf_t nf)

--- a/nf_elem/norm_div.c
+++ b/nf_elem/norm_div.c
@@ -24,7 +24,7 @@
 
 ******************************************************************************/
 
-#include "fmpq.h"
+#include "flint/fmpq.h"
 #include "nf_elem.h"
 
 void _nf_elem_norm_div(fmpz_t rnum, fmpz_t rden, const nf_elem_t a, const nf_t nf, const fmpz_t divisor, slong nbits)

--- a/nf_elem/pow.c
+++ b/nf_elem/pow.c
@@ -28,10 +28,10 @@
 
 #include <stdlib.h>
 #include <gmp.h>
-#include "flint.h"
-#include "fmpz.h"
-#include "fmpz_vec.h"
-#include "fmpz_poly.h"
+#include "flint/flint.h"
+#include "flint/fmpz.h"
+#include "flint/fmpz_vec.h"
+#include "flint/fmpz_poly.h"
 
 void
 _nf_elem_pow(nf_elem_t res, const nf_elem_t a, ulong e, const nf_t nf)

--- a/nf_elem/randtest.c
+++ b/nf_elem/randtest.c
@@ -25,7 +25,7 @@
 ******************************************************************************/
 
 #include "nf_elem.h"
-#include "ulong_extras.h"
+#include "flint/ulong_extras.h"
 
 void nf_elem_randtest(nf_elem_t a, flint_rand_t state, 
                                                mp_bitcnt_t bits, const nf_t nf)

--- a/nf_elem/set_fmpz_mat_row.c
+++ b/nf_elem/set_fmpz_mat_row.c
@@ -27,7 +27,7 @@
 ******************************************************************************/
 
 #include "nf_elem.h"
-#include "fmpq_poly.h"
+#include "flint/fmpq_poly.h"
 
 void nf_elem_set_fmpz_mat_row(nf_elem_t b, const fmpz_mat_t M, 
                                       const slong i, fmpz_t den, const nf_t nf)

--- a/nf_elem/test/t-add_sub.c
+++ b/nf_elem/test/t-add_sub.c
@@ -24,13 +24,8 @@
 ******************************************************************************/
 
 #include <stdio.h>
-#include <gmp.h>
-#include "flint.h"
-#include "fmpz.h"
-#include "fmpz_poly.h"
 #include "nf.h"
 #include "nf_elem.h"
-#include "ulong_extras.h"
 
 int
 main(void)
@@ -44,7 +39,7 @@ main(void)
     flint_randinit(state);
 
     /* test b + c - c = b */
-    for (i = 0; i < 100 * flint_test_multiplier(); i++)
+    for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
         fmpq_poly_t pol;
         nf_t nf;
@@ -89,7 +84,7 @@ main(void)
     }
     
     /* test b + c - c = b : exercise common denominator path */
-    for (i = 0; i < 100 * flint_test_multiplier(); i++)
+    for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
         fmpq_poly_t pol;
         nf_t nf;
@@ -137,7 +132,7 @@ main(void)
     }
     
     /* test aliasing a and b */
-    for (i = 0; i < 100 * flint_test_multiplier(); i++)
+    for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
         fmpq_poly_t pol;
         nf_t nf;
@@ -181,7 +176,7 @@ main(void)
     }
 
     /* test aliasing a and c */
-    for (i = 0; i < 100 * flint_test_multiplier(); i++)
+    for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
         fmpq_poly_t pol;
         nf_t nf;

--- a/nf_elem/test/t-div.c
+++ b/nf_elem/test/t-div.c
@@ -24,13 +24,8 @@
 ******************************************************************************/
 
 #include <stdio.h>
-#include <gmp.h>
-#include "flint.h"
-#include "fmpz.h"
-#include "fmpz_poly.h"
 #include "nf.h"
 #include "nf_elem.h"
-#include "ulong_extras.h"
 
 int
 main(void)
@@ -44,7 +39,7 @@ main(void)
     flint_randinit(state);
 
     /* test a*^-1 = 1 */
-    for (i = 0; i < 10*flint_test_multiplier(); i++)
+    for (i = 0; i < 10*antic_test_multiplier(); i++)
     {
         fmpq_poly_t pol;
         nf_t nf;
@@ -89,7 +84,7 @@ main(void)
     }
     
     /* test aliasing a and b */
-    for (i = 0; i < 10 * flint_test_multiplier(); i++)
+    for (i = 0; i < 10 * antic_test_multiplier(); i++)
     {
         fmpq_poly_t pol;
         nf_t nf;
@@ -133,7 +128,7 @@ main(void)
     }
 
     /* test aliasing a and c */
-    for (i = 0; i < 10 * flint_test_multiplier(); i++)
+    for (i = 0; i < 10 * antic_test_multiplier(); i++)
     {
         fmpq_poly_t pol;
         nf_t nf;

--- a/nf_elem/test/t-get_set_den.c
+++ b/nf_elem/test/t-get_set_den.c
@@ -24,13 +24,8 @@
 ******************************************************************************/
 
 #include <stdio.h>
-#include <gmp.h>
-#include "flint.h"
-#include "fmpz.h"
-#include "fmpz_poly.h"
 #include "nf.h"
 #include "nf_elem.h"
-#include "ulong_extras.h"
 
 int
 main(void)
@@ -43,7 +38,7 @@ main(void)
 
     flint_randinit(state);
 
-    for (i = 0; i < 100 * flint_test_multiplier(); i++)
+    for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
         fmpq_poly_t pol;
         nf_t nf;

--- a/nf_elem/test/t-get_set_fmpq_poly.c
+++ b/nf_elem/test/t-get_set_fmpq_poly.c
@@ -24,13 +24,8 @@
 ******************************************************************************/
 
 #include <stdio.h>
-#include <gmp.h>
-#include "flint.h"
-#include "fmpz.h"
-#include "fmpz_poly.h"
 #include "nf.h"
 #include "nf_elem.h"
-#include "ulong_extras.h"
 
 int
 main(void)
@@ -43,7 +38,7 @@ main(void)
 
     flint_randinit(state);
 
-    for (i = 0; i < 100 * flint_test_multiplier(); i++)
+    for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
         fmpq_poly_t pol;
         fmpq_poly_t f;

--- a/nf_elem/test/t-get_set_fmpz_mat_row.c
+++ b/nf_elem/test/t-get_set_fmpz_mat_row.c
@@ -24,13 +24,8 @@
 ******************************************************************************/
 
 #include <stdio.h>
-#include <gmp.h>
-#include "flint.h"
-#include "fmpz.h"
-#include "fmpz_poly.h"
 #include "nf.h"
 #include "nf_elem.h"
-#include "ulong_extras.h"
 
 int
 main(void)
@@ -43,7 +38,7 @@ main(void)
 
     flint_randinit(state);
 
-    for (i = 0; i < 100 * flint_test_multiplier(); i++)
+    for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
         fmpq_poly_t pol;
         nf_t nf;

--- a/nf_elem/test/t-init_clear.c
+++ b/nf_elem/test/t-init_clear.c
@@ -24,13 +24,8 @@
 ******************************************************************************/
 
 #include <stdio.h>
-#include <gmp.h>
-#include "flint.h"
-#include "fmpz.h"
-#include "fmpz_poly.h"
 #include "nf.h"
 #include "nf_elem.h"
-#include "ulong_extras.h"
 
 int
 main(void)
@@ -43,7 +38,7 @@ main(void)
 
     flint_randinit(state);
 
-    for (i = 0; i < 100 * flint_test_multiplier(); i++)
+    for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
         fmpq_poly_t pol;
         nf_t nf;

--- a/nf_elem/test/t-inv.c
+++ b/nf_elem/test/t-inv.c
@@ -24,13 +24,8 @@
 ******************************************************************************/
 
 #include <stdio.h>
-#include <gmp.h>
-#include "flint.h"
-#include "fmpz.h"
-#include "fmpz_poly.h"
 #include "nf.h"
 #include "nf_elem.h"
-#include "ulong_extras.h"
 
 int
 main(void)
@@ -44,7 +39,7 @@ main(void)
     flint_randinit(state);
 
     /* test a*^-1 = 1 */
-    for (i = 0; i < 10*flint_test_multiplier(); i++)
+    for (i = 0; i < 10*antic_test_multiplier(); i++)
     {
         fmpq_poly_t pol;
         nf_t nf;
@@ -88,7 +83,7 @@ main(void)
     }
     
     /* test aliasing a and b */
-    for (i = 0; i < 10 * flint_test_multiplier(); i++)
+    for (i = 0; i < 10 * antic_test_multiplier(); i++)
     {
         fmpq_poly_t pol;
         nf_t nf;

--- a/nf_elem/test/t-mul.c
+++ b/nf_elem/test/t-mul.c
@@ -24,13 +24,8 @@
 ******************************************************************************/
 
 #include <stdio.h>
-#include <gmp.h>
-#include "flint.h"
-#include "fmpz.h"
-#include "fmpz_poly.h"
 #include "nf.h"
 #include "nf_elem.h"
-#include "ulong_extras.h"
 
 int
 main(void)
@@ -44,7 +39,7 @@ main(void)
     flint_randinit(state);
 
     /* test a*(b + c) = a*b + a*c */
-    for (i = 0; i < 100 * flint_test_multiplier(); i++)
+    for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
         fmpq_poly_t pol;
         nf_t nf;
@@ -104,7 +99,7 @@ main(void)
     }
     
     /* test aliasing a and b */
-    for (i = 0; i < 100 * flint_test_multiplier(); i++)
+    for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
         fmpq_poly_t pol;
         nf_t nf;
@@ -147,7 +142,7 @@ main(void)
     }
 
     /* test aliasing a and c */
-    for (i = 0; i < 100 * flint_test_multiplier(); i++)
+    for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
         fmpq_poly_t pol;
         nf_t nf;

--- a/nf_elem/test/t-mul_gen.c
+++ b/nf_elem/test/t-mul_gen.c
@@ -24,13 +24,8 @@
 ******************************************************************************/
 
 #include <stdio.h>
-#include <gmp.h>
-#include "flint.h"
-#include "fmpz.h"
-#include "fmpz_poly.h"
 #include "nf.h"
 #include "nf_elem.h"
-#include "ulong_extras.h"
 
 int
 main(void)
@@ -44,7 +39,7 @@ main(void)
     flint_randinit(state);
 
     /* test mul_gen(b) = a * b, where a is the generator */
-    for (i = 0; i < 100 * flint_test_multiplier(); i++)
+    for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
         fmpq_poly_t pol;
         nf_t nf;
@@ -92,7 +87,7 @@ main(void)
     }
     
     /* test aliasing b and b */
-    for (i = 0; i < 100 * flint_test_multiplier(); i++)
+    for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
         fmpq_poly_t pol;
         nf_t nf;

--- a/nf_elem/test/t-norm.c
+++ b/nf_elem/test/t-norm.c
@@ -24,13 +24,8 @@
 ******************************************************************************/
 
 #include <stdio.h>
-#include <gmp.h>
-#include "flint.h"
-#include "fmpz.h"
-#include "fmpz_poly.h"
 #include "nf.h"
 #include "nf_elem.h"
-#include "ulong_extras.h"
 
 int
 main(void)
@@ -44,7 +39,7 @@ main(void)
     flint_randinit(state);
 
     /* test norm(a*b) = norm(a)*norm(b) */
-    for (i = 0; i < 10 * flint_test_multiplier(); i++)
+    for (i = 0; i < 10 * antic_test_multiplier(); i++)
     {
         fmpq_poly_t pol;
         nf_t nf;

--- a/nf_elem/test/t-norm_div.c
+++ b/nf_elem/test/t-norm_div.c
@@ -24,13 +24,8 @@
 ******************************************************************************/
 
 #include <stdio.h>
-#include <gmp.h>
-#include "flint.h"
-#include "fmpz.h"
-#include "fmpz_poly.h"
 #include "nf.h"
 #include "nf_elem.h"
-#include "ulong_extras.h"
 
 int
 main(void)
@@ -43,7 +38,7 @@ main(void)
 
     flint_randinit(state);
 
-    for (i = 0; i < 10 * flint_test_multiplier(); i++)
+    for (i = 0; i < 10 * antic_test_multiplier(); i++)
     {
         fmpq_poly_t pol;
         fmpz_poly_t pol2;

--- a/nf_elem/test/t-pow.c
+++ b/nf_elem/test/t-pow.c
@@ -24,13 +24,8 @@
 ******************************************************************************/
 
 #include <stdio.h>
-#include <gmp.h>
-#include "flint.h"
-#include "fmpz.h"
-#include "fmpz_poly.h"
 #include "nf.h"
 #include "nf_elem.h"
-#include "ulong_extras.h"
 
 int
 main(void)
@@ -44,7 +39,7 @@ main(void)
     flint_randinit(state);
 
     /* test pow(a, e) = e*e*...*e */
-    for (i = 0; i < 100 * flint_test_multiplier(); i++)
+    for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
         fmpq_poly_t pol;
         nf_t nf;
@@ -93,7 +88,7 @@ main(void)
     }
     
     /* test aliasing a and res */
-    for (i = 0; i < 100 * flint_test_multiplier(); i++)
+    for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
         fmpq_poly_t pol;
         nf_t nf;

--- a/nf_elem/test/t-rep_mat.c
+++ b/nf_elem/test/t-rep_mat.c
@@ -24,14 +24,9 @@
 ******************************************************************************/
 
 #include <stdio.h>
-#include <gmp.h>
-#include "flint.h"
-#include "fmpz.h"
-#include "fmpz_poly.h"
-#include "fmpq_mat.h"
+#include "flint/fmpq_mat.h"
 #include "nf.h"
 #include "nf_elem.h"
-#include "ulong_extras.h"
 
 int
 main(void)
@@ -45,7 +40,7 @@ main(void)
     flint_randinit(state);
 
     /* test mul_gen(b) = a * b, where a is the generator */
-    for (i = 0; i < 100 * flint_test_multiplier(); i++)
+    for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
         fmpq_poly_t pol;
         nf_t nf;

--- a/nf_elem/test/t-rep_mat_fmpz_mat_den.c
+++ b/nf_elem/test/t-rep_mat_fmpz_mat_den.c
@@ -24,14 +24,9 @@
 ******************************************************************************/
 
 #include <stdio.h>
-#include <gmp.h>
-#include "flint.h"
-#include "fmpz.h"
-#include "fmpz_poly.h"
-#include "fmpq_mat.h"
+#include "flint/fmpq_mat.h"
 #include "nf.h"
 #include "nf_elem.h"
-#include "ulong_extras.h"
 
 int
 main(void)
@@ -45,7 +40,7 @@ main(void)
     flint_randinit(state);
 
     /* test mul_gen(b) = a * b, where a is the generator */
-    for (i = 0; i < 100 * flint_test_multiplier(); i++)
+    for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
         fmpq_poly_t pol;
         nf_t nf;

--- a/nf_elem/test/t-set_equal.c
+++ b/nf_elem/test/t-set_equal.c
@@ -24,13 +24,8 @@
 ******************************************************************************/
 
 #include <stdio.h>
-#include <gmp.h>
-#include "flint.h"
-#include "fmpz.h"
-#include "fmpz_poly.h"
 #include "nf.h"
 #include "nf_elem.h"
-#include "ulong_extras.h"
 
 int
 main(void)
@@ -44,7 +39,7 @@ main(void)
     flint_randinit(state);
 
     /* set a = b, check a == b */
-    for (i = 0; i < 100 * flint_test_multiplier(); i++)
+    for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
         fmpq_poly_t pol;
         nf_t nf;
@@ -82,7 +77,7 @@ main(void)
     }
 
     /* test aliasing a and b */
-    for (i = 0; i < 100 * flint_test_multiplier(); i++)
+    for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
         fmpq_poly_t pol;
         nf_t nf;

--- a/nf_elem/test/t-trace.c
+++ b/nf_elem/test/t-trace.c
@@ -24,13 +24,8 @@
 ******************************************************************************/
 
 #include <stdio.h>
-#include <gmp.h>
-#include "flint.h"
-#include "fmpz.h"
-#include "fmpz_poly.h"
 #include "nf.h"
 #include "nf_elem.h"
-#include "ulong_extras.h"
 
 int
 main(void)
@@ -44,7 +39,7 @@ main(void)
     flint_randinit(state);
 
     /* test trace(a + b) = trace(a) + trace(b) */
-    for (i = 0; i < 100 * flint_test_multiplier(); i++)
+    for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
         fmpq_poly_t pol;
         nf_t nf;

--- a/nf_elem/trace.c
+++ b/nf_elem/trace.c
@@ -23,7 +23,7 @@
 
 ******************************************************************************/
 
-#include "fmpq.h"
+#include "flint/fmpq.h"
 #include "nf_elem.h"
 
 void _nf_elem_trace(fmpz_t rnum, fmpz_t rden, const nf_elem_t a, const nf_t nf)

--- a/qfb.h
+++ b/qfb.h
@@ -27,8 +27,8 @@
 #define QFB_H
 
 #include <gmp.h>
-#include "flint.h"
-#include "fmpz.h"
+#include "flint/flint.h"
+#include "flint/fmpz.h"
 
 #ifdef __cplusplus
  extern "C" {

--- a/qfb/exponent.c
+++ b/qfb/exponent.c
@@ -25,9 +25,9 @@
 
 #include <stdlib.h>
 #include <gmp.h>
-#include "flint.h"
-#include "ulong_extras.h"
-#include "fmpz.h"
+#include "flint/flint.h"
+#include "flint/ulong_extras.h"
+#include "flint/fmpz.h"
 #include "qfb.h"
 
 int qfb_exponent(fmpz_t exponent, fmpz_t n, ulong B1, ulong B2_sqrt, slong c)

--- a/qfb/exponent_element.c
+++ b/qfb/exponent_element.c
@@ -25,9 +25,6 @@
 
 #include <stdlib.h>
 #include <gmp.h>
-#include "flint.h"
-#include "ulong_extras.h"
-#include "fmpz.h"
 #include "qfb.h"
 
 /*

--- a/qfb/exponent_grh.c
+++ b/qfb/exponent_grh.c
@@ -26,9 +26,6 @@
 #include <stdlib.h>
 #include <gmp.h>
 #include <mpfr.h>
-#include "flint.h"
-#include "ulong_extras.h"
-#include "fmpz.h"
 #include "qfb.h"
 
 int qfb_exponent_grh(fmpz_t exponent, fmpz_t n, ulong B1, ulong B2_sqrt)

--- a/qfb/hash_clear.c
+++ b/qfb/hash_clear.c
@@ -25,9 +25,6 @@
 
 #include <stdlib.h>
 #include <gmp.h>
-#include "flint.h"
-#include "ulong_extras.h"
-#include "fmpz.h"
 #include "qfb.h"
 
 void qfb_hash_clear(qfb_hash_t * qhash, slong depth)

--- a/qfb/hash_find.c
+++ b/qfb/hash_find.c
@@ -25,9 +25,7 @@
 
 #include <stdlib.h>
 #include <gmp.h>
-#include "flint.h"
-#include "ulong_extras.h"
-#include "fmpz.h"
+#include "flint/fmpz.h"
 #include "qfb.h"
 
 slong qfb_hash_find(qfb_hash_t * qhash, qfb_t q, slong depth)

--- a/qfb/hash_init.c
+++ b/qfb/hash_init.c
@@ -25,9 +25,6 @@
 
 #include <stdlib.h>
 #include <gmp.h>
-#include "flint.h"
-#include "ulong_extras.h"
-#include "fmpz.h"
 #include "qfb.h"
 
 qfb_hash_t * qfb_hash_init(slong depth)

--- a/qfb/hash_insert.c
+++ b/qfb/hash_insert.c
@@ -25,9 +25,7 @@
 
 #include <stdlib.h>
 #include <gmp.h>
-#include "flint.h"
-#include "ulong_extras.h"
-#include "fmpz.h"
+#include "flint/fmpz.h"
 #include "qfb.h"
 
 void qfb_hash_insert(qfb_hash_t * qhash, qfb_t q, qfb_t q2, slong iter, slong depth)

--- a/qfb/is_reduced.c
+++ b/qfb/is_reduced.c
@@ -25,9 +25,9 @@
 
 #include <stdlib.h>
 #include <gmp.h>
-#include "flint.h"
-#include "ulong_extras.h"
-#include "fmpz.h"
+#include "flint/flint.h"
+#include "flint/ulong_extras.h"
+#include "flint/fmpz.h"
 #include "qfb.h"
 
 int qfb_is_reduced(qfb_t r)

--- a/qfb/nucomp.c
+++ b/qfb/nucomp.c
@@ -25,9 +25,6 @@
 
 #include <stdlib.h>
 #include <gmp.h>
-#include "flint.h"
-#include "ulong_extras.h"
-#include "fmpz.h"
 #include "qfb.h"
 
 /*

--- a/qfb/nudupl.c
+++ b/qfb/nudupl.c
@@ -25,9 +25,9 @@
 
 #include <stdlib.h>
 #include <gmp.h>
-#include "flint.h"
-#include "ulong_extras.h"
-#include "fmpz.h"
+#include "flint/flint.h"
+#include "flint/ulong_extras.h"
+#include "flint/fmpz.h"
 #include "qfb.h"
 
 void qfb_nudupl(qfb_t r, const qfb_t f, fmpz_t D, fmpz_t L)

--- a/qfb/pow.c
+++ b/qfb/pow.c
@@ -25,9 +25,9 @@
 
 #include <stdlib.h>
 #include <gmp.h>
-#include "flint.h"
-#include "ulong_extras.h"
-#include "fmpz.h"
+#include "flint/flint.h"
+#include "flint/ulong_extras.h"
+#include "flint/fmpz.h"
 #include "qfb.h"
 
 void qfb_pow(qfb_t r, qfb_t f, fmpz_t D, fmpz_t e)

--- a/qfb/pow_ui.c
+++ b/qfb/pow_ui.c
@@ -25,9 +25,7 @@
 
 #include <stdlib.h>
 #include <gmp.h>
-#include "flint.h"
-#include "ulong_extras.h"
-#include "fmpz.h"
+#include "flint/fmpz.h"
 #include "qfb.h"
 
 void qfb_pow_ui(qfb_t r, qfb_t f, fmpz_t D, ulong exp)

--- a/qfb/prime_form.c
+++ b/qfb/prime_form.c
@@ -25,9 +25,9 @@
 
 #include <stdlib.h>
 #include <gmp.h>
-#include "flint.h"
-#include "ulong_extras.h"
-#include "fmpz.h"
+#include "flint/flint.h"
+#include "flint/ulong_extras.h"
+#include "flint/fmpz.h"
 #include "qfb.h"
 
 void qfb_prime_form(qfb_t r, fmpz_t D, fmpz_t p)

--- a/qfb/reduce.c
+++ b/qfb/reduce.c
@@ -25,9 +25,6 @@
 
 #include <stdlib.h>
 #include <gmp.h>
-#include "flint.h"
-#include "ulong_extras.h"
-#include "fmpz.h"
 #include "qfb.h"
 
 void qfb_reduce(qfb_t r, qfb_t f, fmpz_t D)

--- a/qfb/reduced_forms.c
+++ b/qfb/reduced_forms.c
@@ -25,9 +25,6 @@
 
 #include <stdlib.h>
 #include <gmp.h>
-#include "flint.h"
-#include "ulong_extras.h"
-#include "fmpz.h"
 #include "qfb.h"
 
 /*

--- a/qfb/test/t-exponent.c
+++ b/qfb/test/t-exponent.c
@@ -25,10 +25,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <gmp.h>
-#include "flint.h"
-#include "ulong_extras.h"
-#include "fmpz.h"
 #include "qfb.h"
 
 int main(void)

--- a/qfb/test/t-exponent_element.c
+++ b/qfb/test/t-exponent_element.c
@@ -25,10 +25,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <gmp.h>
-#include "flint.h"
-#include "ulong_extras.h"
-#include "fmpz.h"
 #include "qfb.h"
 
 int main(void)

--- a/qfb/test/t-exponent_grh.c
+++ b/qfb/test/t-exponent_grh.c
@@ -25,10 +25,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <gmp.h>
-#include "flint.h"
-#include "ulong_extras.h"
-#include "fmpz.h"
 #include "qfb.h"
 
 int main(void)

--- a/qfb/test/t-inverse.c
+++ b/qfb/test/t-inverse.c
@@ -25,10 +25,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <gmp.h>
-#include "flint.h"
-#include "ulong_extras.h"
-#include "fmpz.h"
 #include "qfb.h"
 
 int main(void)

--- a/qfb/test/t-nucomp.c
+++ b/qfb/test/t-nucomp.c
@@ -25,10 +25,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <gmp.h>
-#include "flint.h"
-#include "ulong_extras.h"
-#include "fmpz.h"
 #include "qfb.h"
 
 int main(void)

--- a/qfb/test/t-nudupl.c
+++ b/qfb/test/t-nudupl.c
@@ -25,10 +25,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <gmp.h>
-#include "flint.h"
-#include "ulong_extras.h"
-#include "fmpz.h"
 #include "qfb.h"
 
 int main(void)

--- a/qfb/test/t-pow.c
+++ b/qfb/test/t-pow.c
@@ -25,10 +25,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <gmp.h>
-#include "flint.h"
-#include "ulong_extras.h"
-#include "fmpz.h"
 #include "qfb.h"
 
 int main(void)

--- a/qfb/test/t-pow_ui.c
+++ b/qfb/test/t-pow_ui.c
@@ -25,10 +25,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <gmp.h>
-#include "flint.h"
-#include "ulong_extras.h"
-#include "fmpz.h"
 #include "qfb.h"
 
 int main(void)

--- a/qfb/test/t-prime_form.c
+++ b/qfb/test/t-prime_form.c
@@ -25,10 +25,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <gmp.h>
-#include "flint.h"
-#include "ulong_extras.h"
-#include "fmpz.h"
 #include "qfb.h"
 
 int main(void)

--- a/qfb/test/t-reduce.c
+++ b/qfb/test/t-reduce.c
@@ -25,10 +25,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <gmp.h>
-#include "flint.h"
-#include "ulong_extras.h"
-#include "fmpz.h"
 #include "qfb.h"
 
 int main(void)

--- a/qfb/test/t-reduced_forms.c
+++ b/qfb/test/t-reduced_forms.c
@@ -25,10 +25,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <gmp.h>
-#include "flint.h"
-#include "ulong_extras.h"
-#include "fmpz.h"
 #include "qfb.h"
 
 int main(void)


### PR DESCRIPTION
Adding a configure/make toolchain (mainly copying the one from arb). Currently, the headers are installed directly in `include/`. Do you prefer `include/antic/`?