### PR TITLE
Fix mod_fmpz function and add coprime_den function

### DIFF
--- a/nf_elem.h
+++ b/nf_elem.h
@@ -954,6 +954,10 @@ void nf_elem_mod_fmpz_den(nf_elem_t res, const nf_elem_t a, const fmpz_t mod, co
 FLINT_DLL
 void nf_elem_mod_fmpz(nf_elem_t res, const nf_elem_t a, const fmpz_t mod, const nf_t nf);
 
+FLINT_DLL
+void
+nf_elem_coprime_den(nf_elem_t res, const nf_elem_t a, const fmpz_t mod, const nf_t nf);
+
 #ifdef __cplusplus
 }
 #endif

--- a/nf_elem/doc/nf_elem.txt
+++ b/nf_elem/doc/nf_elem.txt
@@ -367,12 +367,18 @@ void nf_elem_mod_fmpz_den(nf_elem_t z, const nf_elem_t a, const fmpz_t mod, cons
     the coefficients of $z - da$ are divisble by \code{mod}, where $d$ is the
     denominator of $a$. The coefficients of $z$ are reduced modulo \code{mod}.
 
-    If \code{den == 1}, return an element $z$ with denominator $1$, such that
-    the coefficients of $z - a$ are divisble by \code{mod}. The coefficients of
-    $z$ are reduced modulo \code{mod * d}, where $d$ is the denominator of $a$.
+    If \code{den == 1}, return an element $z$, such that $z - a$ has
+    denominator $1$ and the coefficients of $z - a$ are divisble by \code{mod}.
+    The coefficients of $z$ are reduced modulo \code{mod * d}, where $d$ is the
+    denominator of $a$.
 
 void nf_elem_mod_fmpz(nf_elem_t res, const nf_elem_t a, const fmpz_t mod, const nf_t nf);
 
-    Return an element $z$ with denominator $1$ such that the coefficients of $z
-    -a$ are divisible by \code{mod}. The coefficients of $z$ are reduced
-    modulo \code{mod * d}, where $d$ is the denominator of $b$.
+    Return an element $z$ such that $z - a$ has denominator $1$ and the
+    coefficients of $z - a$ are divisible by \code{mod}. The coefficients of
+    $z$ are reduced modulo \code{mod * d}, where $d$ is the denominator of $b$.
+
+void nf_elem_coprime_den(nf_elem_t res, const nf_elem_t a, const fmpz_t mod, const nf_t nf);
+
+    Return an element $z$ such that the denominator of $z - a$ is coprime to
+    \code{mod}.

--- a/nf_elem/mod_fmpz.c
+++ b/nf_elem/mod_fmpz.c
@@ -71,6 +71,19 @@ nf_elem_mod_fmpz_den(nf_elem_t res, const nf_elem_t a, const fmpz_t mod, const n
 
         _nf_elem_mod_fmpz(res, a, t, nf);
 
+        if (nf->flag & NF_LINEAR)
+        {
+            nf_elem_scalar_div_fmpz(res, res, LNF_ELEM_DENREF(a), nf);
+        }
+        else if (nf->flag & NF_QUADRATIC)
+        {
+            nf_elem_scalar_div_fmpz(res, res, QNF_ELEM_DENREF(a), nf);
+        }
+        else 
+        {
+            nf_elem_scalar_div_fmpz(res, res, NF_ELEM_DENREF(a), nf);
+        }
+
         fmpz_clear(t);
     }
 }
@@ -78,4 +91,99 @@ nf_elem_mod_fmpz_den(nf_elem_t res, const nf_elem_t a, const fmpz_t mod, const n
 void nf_elem_mod_fmpz(nf_elem_t res, const nf_elem_t a, const fmpz_t mod, const nf_t nf)
 {
     nf_elem_mod_fmpz_den(res, a, mod, nf, 1);
+}
+    
+static void
+_fmpz_ppio(fmpz_t ppi, fmpz_t ppo, const fmpz_t a, const fmpz_t b)
+{
+    fmpz_t c, n, g;
+
+    fmpz_init(c);
+    fmpz_init(n);
+    fmpz_init(g);
+
+    fmpz_gcd(c, a, b);
+    fmpz_divexact(n, a, c);
+    fmpz_gcd(g, c, n);
+
+    while (!fmpz_is_one(g))
+    {
+        fmpz_mul(c, c, g);
+        fmpz_divexact(n, n, g);
+        fmpz_gcd(g, c, n);
+    }
+    fmpz_set(ppi, c);
+    fmpz_set(ppo, n);
+
+    fmpz_clear(c);
+    fmpz_clear(n);
+    fmpz_clear(g);
+}
+
+void
+nf_elem_coprime_den(nf_elem_t res, const nf_elem_t a, const fmpz_t mod, const nf_t nf)
+{
+    if (nf_elem_is_zero(a, nf))
+    {
+        nf_elem_zero(res, nf);
+        return;
+    }
+
+    if (nf_elem_den_is_one(a, nf))
+    {
+        nf_elem_mod_fmpz_den(res, a, mod, nf, 0);
+        return ;
+    }
+
+    if (nf->flag & NF_LINEAR)
+    {
+        fmpz_t c, nc;
+        fmpz_init(c);
+        fmpz_init(nc);
+
+        _fmpz_ppio(c, nc, LNF_ELEM_DENREF(a), mod);
+        fmpz_mul(LNF_ELEM_DENREF(res), mod, c);
+        fmpz_invmod(nc, nc, LNF_ELEM_DENREF(res));
+        fmpz_mul(LNF_ELEM_NUMREF(res), LNF_ELEM_NUMREF(a), nc);
+        fmpz_mod(LNF_ELEM_NUMREF(res), LNF_ELEM_NUMREF(res), LNF_ELEM_DENREF(res));
+        fmpz_set(LNF_ELEM_DENREF(res), c);
+
+        fmpz_clear(c);
+        fmpz_clear(nc);
+    }
+    else if (nf->flag & NF_QUADRATIC)
+    { 
+        fmpz_t c, nc;
+        fmpz_init(c);
+        fmpz_init(nc);
+
+        _fmpz_ppio(c, nc, QNF_ELEM_DENREF(a), mod);
+        fmpz_mul(QNF_ELEM_DENREF(res), mod, c);
+        fmpz_invmod(nc, nc, QNF_ELEM_DENREF(res));
+        _fmpz_vec_scalar_mul_fmpz(QNF_ELEM_NUMREF(res), QNF_ELEM_NUMREF(a), 3, nc);
+        _fmpz_vec_scalar_mod_fmpz(QNF_ELEM_NUMREF(res), QNF_ELEM_NUMREF(res), 3, QNF_ELEM_DENREF(res));
+        fmpz_set(QNF_ELEM_DENREF(res), c);
+        
+        fmpz_clear(c);
+        fmpz_clear(nc);
+    }
+    else
+    {
+        fmpz_t c, nc;
+        fmpz_init(c);
+        fmpz_init(nc);
+
+        fmpq_poly_fit_length(NF_ELEM(res), fmpq_poly_length(NF_ELEM(a)));
+        _fmpz_ppio(c, nc, NF_ELEM_DENREF(a), mod);
+        fmpz_mul(NF_ELEM_DENREF(res), mod, c);
+        fmpz_invmod(nc, nc, NF_ELEM_DENREF(res));
+        _fmpz_vec_scalar_mul_fmpz(NF_ELEM(res)->coeffs, NF_ELEM(a)->coeffs, fmpq_poly_length(NF_ELEM(a)), nc);
+        _fmpz_vec_scalar_mod_fmpz(NF_ELEM(res)->coeffs, NF_ELEM(res)->coeffs, fmpq_poly_length(NF_ELEM(a)), NF_ELEM_DENREF(res));
+        fmpz_set(NF_ELEM_DENREF(res), c);
+        _fmpq_poly_set_length(NF_ELEM(res), fmpq_poly_length(NF_ELEM(a)));
+
+        fmpz_clear(c);
+        fmpz_clear(nc);
+    }
+    nf_elem_canonicalise(res, nf);
 }

--- a/nf_elem/test/t-mod_fmpz.c
+++ b/nf_elem/test/t-mod_fmpz.c
@@ -98,15 +98,14 @@ main(void)
         slong j;
         fmpq_poly_t pol;
         nf_t nf;
-        nf_elem_t a, b;
-        fmpz_t coeff, mod, reduced_coeff, den;
+        nf_elem_t a, b, c;
+        fmpz_t coeff, mod, den;
 
         fmpz_init(mod);
         fmpz_randtest_unsigned(mod, state, 2 * FLINT_BITS);
         fmpz_add_ui(mod, mod, 2);
 
         fmpz_init(coeff);
-        fmpz_init(reduced_coeff);
         fmpz_init(den);
 
         fmpq_poly_init(pol);
@@ -118,36 +117,92 @@ main(void)
 
         nf_elem_init(a, nf);
         nf_elem_init(b, nf);
+        nf_elem_init(c, nf);
 
         nf_elem_randtest(a, state, 2, nf);
-        nf_elem_get_den(den, a, nf);
-        fmpz_mul(den, den, mod);
 
         nf_elem_mod_fmpz(b, a, mod, nf);
 
+        nf_elem_sub(c, b, a, nf);
+
         for (j = 0; j < fmpq_poly_degree(pol); j++)
         {
-            nf_elem_get_coeff_fmpz(coeff, a, j, nf);
-            fmpz_mod(coeff, coeff, den);
-            nf_elem_get_coeff_fmpz(reduced_coeff, b, j, nf);
-            result = fmpz_equal(reduced_coeff, coeff);
-            if (!result)
+            nf_elem_get_coeff_fmpz(coeff, c, j, nf);
+            fmpz_mod(coeff, coeff, mod);
+            result = fmpz_is_zero(coeff);
+            if (!result || !nf_elem_den_is_one(c, nf))
             {
                 printf("FAIL: Reducing without denominator\n");
                 printf("f = "); fmpq_poly_print_pretty(pol, "x"); printf("\n");
                 printf("a = "); nf_elem_print_pretty(a, nf, "x"); printf("\n");
-                printf("n = "); fmpz_print(mod); printf("\n");
                 printf("b = "); nf_elem_print_pretty(b, nf, "x"); printf("\n");
+                printf("c = "); nf_elem_print_pretty(c, nf, "x"); printf("\n");
+                printf("n = "); fmpz_print(mod); printf("\n");
                 abort();
             }
         }
 
         nf_elem_clear(a, nf);
         nf_elem_clear(b, nf);
+        nf_elem_clear(c, nf);
         fmpz_clear(coeff);
-        fmpz_clear(reduced_coeff);
         fmpz_clear(mod);
         fmpz_clear(den);
+        nf_clear(nf);
+        fmpq_poly_clear(pol);
+    }
+
+    for (i = 0; i < 100 * antic_test_multiplier(); i++)
+    {
+        fmpq_poly_t pol;
+        nf_t nf;
+        nf_elem_t a, b, c;
+        fmpz_t mod, den, gcd;
+
+        fmpz_init(mod);
+        fmpz_randtest_unsigned(mod, state, 2 * FLINT_BITS);
+        fmpz_add_ui(mod, mod, 2);
+
+        fmpz_init(den);
+        fmpz_init(gcd);
+
+        fmpq_poly_init(pol);
+        do {
+            fmpq_poly_randtest_not_zero(pol, state, 4, 2);
+        } while (fmpq_poly_degree(pol) < 1);
+
+        nf_init(nf, pol);
+
+        nf_elem_init(a, nf);
+        nf_elem_init(b, nf);
+        nf_elem_init(c, nf);
+
+        nf_elem_randtest(a, state, 2, nf);
+
+        nf_elem_coprime_den(b, a, mod, nf);
+
+        nf_elem_sub(c, b, a, nf);
+
+        nf_elem_get_den(den, c, nf);
+        fmpz_gcd(gcd, den, mod);
+
+        if (!fmpz_is_one(gcd))
+        {
+            printf("FAIL: Coprime denominators\n");
+            printf("f = "); fmpq_poly_print_pretty(pol, "x"); printf("\n");
+            printf("a = "); nf_elem_print_pretty(a, nf, "x"); printf("\n");
+            printf("b = "); nf_elem_print_pretty(b, nf, "x"); printf("\n");
+            printf("c = "); nf_elem_print_pretty(c, nf, "x"); printf("\n");
+            printf("n = "); fmpz_print(mod); printf("\n");
+            abort();
+        }
+
+        nf_elem_clear(a, nf);
+        nf_elem_clear(b, nf);
+        nf_elem_clear(c, nf);
+        fmpz_clear(mod);
+        fmpz_clear(den);
+        fmpz_clear(gcd);
         nf_clear(nf);
         fmpq_poly_clear(pol);
     }


### PR DESCRIPTION
I don't know what I was thinking. The `nf_elem_mod_fmpz` was not doing what it was supposed to do.

I also added another handy function including tests.