### PR TITLE
Fix another bug in nf_elem_fmpq_sub

### DIFF
--- a/nf_elem/fmpq_sub.c
+++ b/nf_elem/fmpq_sub.c
@@ -59,6 +59,7 @@ void nf_elem_fmpq_sub(nf_elem_t a, const fmpq_t c, const nf_elem_t b, const nf_t
 		 if (fmpz_equal(fmpq_denref(c), den2))
 		 {
     		fmpz_sub(num, fmpq_numref(c), num2);
+            fmpz_neg(num + 1, num2 + 1);
 			fmpz_set(den, den2);
 		 } else /* slow path */
 		 {
@@ -73,7 +74,7 @@ void nf_elem_fmpq_sub(nf_elem_t a, const fmpq_t c, const nf_elem_t b, const nf_t
 	        fmpz_gcd(g, fmpq_denref(c), den);
 			fmpz_divexact(d1, fmpq_denref(c), g);
 			fmpz_divexact(d2, den, g);
-			
+
 			fmpz_mul(num + 1, num + 1, d1);
 			fmpz_mul(num, num, d1);
 			fmpz_mul(den, den, d1);


### PR DESCRIPTION
Found when running
```julia
julia> d = [ d for d in -100:100 if d !=0 && abs(d) != 1 && issquarefree(d) ];

julia> Qx, x = FlintQQ["x"];

julia> for n in d
         K, a = NumberField(x^2 - n);
         for k in 1:10 
           z = rand(K, -10:10);
           for i in 0:100; for j in 1:100
             @assert z - i == z - K(i)
             @assert z + i == z + K(i)
             @assert i + z == K(i) + z
             @assert i - z == K(i) - z
             @assert z - fmpq(i, j) == z - K(fmpq(i, j))
             @assert z + fmpq(i, j) == z + K(fmpq(i, j))
             @assert fmpq(i, j) - z == K(fmpq(i, j)) - z
             @assert fmpq(i, j) + z == K(fmpq(i, j)) + z
           end end
         end
       end
```
With this fix the above tests pass.