### PR TITLE
Fix testing on macOS

### DIFF
--- a/Makefile.subdirs
+++ b/Makefile.subdirs
@@ -41,10 +41,10 @@ profile: $(PROFS)
 -include $(patsubst %, %.d, $(PROFS))
 
 $(BUILD_DIR)/profile/%$(EXEEXT): profile/%.c $(BUILD_DIR)/../profiler.o
-	$(QUIET_CC) $(CC) $(ABI_FLAG) -O2 -std=c99 -g $(INCS) $< $(BUILD_DIR)/../profiler.o -o $@ $(LIBS)  -MMD -MP -MF $@.d -MT "$@" -MT "$@.d"
+	$(QUIET_CC) $(CC) $(ABI_FLAG) -O2 -std=c99 -g $(INCS) $< $(BUILD_DIR)/../profiler.o -o $@ $(LDFLAGS) $(LIBS)  -MMD -MP -MF $@.d -MT "$@" -MT "$@.d"
 
 tune: $(TUNE_SOURCES) $(HEADERS)
-	$(AT)$(foreach prog, $(TUNE), $(CC) $(CFLAGS) $(INCS) $(prog).c -o $(BUILD_DIR)/$(prog) $(LIBS) || exit $$?;)
+	$(AT)$(foreach prog, $(TUNE), $(CC) $(CFLAGS) $(INCS) $(prog).c -o $(BUILD_DIR)/$(prog) $(LDFLAGS) $(LIBS) || exit $$?;)
 
 -include $(OBJS:.o=.d)
 
@@ -75,10 +75,10 @@ $(BUILD_DIR)/test/%$(EXEEXT): $(BUILD_DIR)/../../libantic.a
 endif
 
 $(BUILD_DIR)/test/%$(EXEEXT): test/%.c
-	$(QUIET_CC) $(CC) $(CFLAGS) $(INCS) $< -o $@ $(LIBS) -MMD -MP -MF $@.d -MT "$@" -MT "$@.d"
+	$(QUIET_CC) $(CC) $(CFLAGS) $(INCS) $< -o $@ $(LDFLAGS) $(LIBS) -MMD -MP -MF $@.d -MT "$@" -MT "$@.d"
 
 $(BUILD_DIR)/test/%$(EXEEXT): test/%.cpp $(BUILD_DIR)/../../test_helpers.o
-	$(QUIET_CC) $(CXX) $(CFLAGS) $(INCS) $< -o $@ $(LIBS) -MMD -MP -MF $@.d -MT "$@" -MT "$@.d"
+	$(QUIET_CC) $(CXX) $(CFLAGS) $(INCS) $< -o $@ $(LDFLAGS) $(LIBS) -MMD -MP -MF $@.d -MT "$@" -MT "$@.d"
 
 %_RUN: %
 	@$<


### PR DESCRIPTION
When building these binaries with libraries such as FLINT in a
nonstandard place, we need to pass in LDFLAGS so that they can be found.

see https://github.com/conda-forge/staged-recipes/pull/11929