### PR TITLE
Introduce nf_init_randtest to simplify testing

### DIFF
--- a/.check_post_install
+++ b/.check_post_install
@@ -13,24 +13,17 @@ cat > test.c <<EOL
 
 int main(void)
 {
-    fmpq_poly_t pol;
     nf_t nf;
     nf_elem_t a;
     flint_rand_t state;
 
     flint_randinit(state);
-    fmpq_poly_init(pol);
-    do {
-       fmpq_poly_randtest_not_zero(pol, state, 5, 20);
-    } while (fmpq_poly_degree(pol) < 1);
-
-    nf_init(nf, pol);
+    nf_init_randtest(nf, state, 5, 20);
 
     nf_elem_init(a, nf);
 
     nf_elem_clear(a, nf);
     nf_clear(nf);
-    fmpq_poly_clear(pol);
     flint_randclear(state);
     flint_cleanup();
 

--- a/nf.h
+++ b/nf.h
@@ -60,6 +60,8 @@ typedef nf_struct nf_t[1];
 
 FLINT_DLL void nf_init(nf_t nf, const fmpq_poly_t pol);
 
+FLINT_DLL void nf_init_randtest(nf_t nf, flint_rand_t state, slong len,  mp_bitcnt_t bits_in);
+
 FLINT_DLL void nf_clear(nf_t nf);
 
 FLINT_DLL void nf_print(const nf_t nf);

--- a/nf/init_randtest.c
+++ b/nf/init_randtest.c
@@ -1,0 +1,59 @@
+/*=============================================================================
+
+    This file is part of ANTIC.
+
+    Antic is free software: you can redistribute it and/or modify it under
+    the terms of the GNU Lesser General Public License (LGPL) as published
+    by the Free Software Foundation; either version 2.1 of the License, or
+    (at your option) any later version. See <http://www.gnu.org/licenses/>.
+
+=============================================================================*/
+/******************************************************************************
+
+    Copyright (C) 2019 Vincent Delecroix
+
+******************************************************************************/
+
+#include "nf.h"
+
+void nf_init_randtest(nf_t nf, flint_rand_t state,
+        slong len,
+        mp_bitcnt_t bits_in)
+{
+    fmpq_poly_t pol;
+    fmpz_poly_t q;
+
+    if (len < 2 || bits_in < 1)
+    {
+        fprintf(stderr, "[nf_init_randtest] len must be >= 2 and bits_in >= 1\n");
+        abort();
+    }
+
+    if (len <= 2 || n_randint(state, 30) == 0)
+        len = 2; /* linear */
+    else if (len <= 3 || n_randint(state, 30) == 0)
+        len = 3; /* quadratic */
+    else
+        len = 3 + n_randint(state, len-2);
+
+    fmpz_poly_init(q);
+    do {
+        fmpz_poly_randtest(q,
+                state,
+                len,
+                1 + n_randint(state, bits_in));
+    } while (fmpz_poly_degree(q) < 1 || fmpz_is_zero(q->coeffs));
+
+    fmpq_poly_init(pol);
+    fmpq_poly_set_fmpz_poly(pol, q);
+
+    if (n_randint(state, 5) == 0)
+        fmpz_one(pol->coeffs + pol->length - 1); /* monic */
+    else
+        fmpz_randtest_not_zero(fmpq_poly_denref(pol), state, bits_in);
+    fmpq_poly_canonicalise(pol);
+
+    nf_init(nf, pol);
+    fmpq_poly_clear(pol);
+    fmpz_poly_clear(q);
+}

--- a/nf/test/t-init_clear.c
+++ b/nf/test/t-init_clear.c
@@ -11,6 +11,7 @@
 /******************************************************************************
 
     Copyright (C) 2013 William Hart
+                  2019 Vincent Delecroix
 
 ******************************************************************************/
 
@@ -28,24 +29,67 @@ main(void)
 
     flint_randinit(state);
 
-    for (i = 0; i < 1000 * antic_test_multiplier(); i++)
+    /* not necessarily monic */
+    for (i = 0; i < 500 * antic_test_multiplier(); i++)
+    {
+        nf_t nf;
+        fmpq_poly_t pol;
+
+        fmpq_poly_init(pol);
+        do {
+           fmpq_poly_randtest_not_zero(pol, state,
+                   2 + n_randint(state, 40),
+                   10 + n_randint(state, 200));
+        } while (fmpq_poly_degree(pol) < 1);
+
+        nf_init(nf, pol);
+        nf_clear(nf);
+
+        nf_init(nf, pol);
+        fmpq_poly_clear(pol);
+        nf_clear(nf);
+    }
+
+    /* monic */
+    for (i = 0; i < 500 * antic_test_multiplier(); i++)
     {
         fmpq_poly_t pol;
         nf_t nf;
 
         fmpq_poly_init(pol);
         do {
-           fmpq_poly_randtest_not_zero(pol, state, 40, 200);
+           fmpq_poly_randtest_not_zero(pol, state,
+                   2 + n_randint(state, 40),
+                   10 + n_randint(state, 200));
         } while (fmpq_poly_degree(pol) < 1);
+        fmpz_one(fmpq_poly_denref(pol));
+        fmpz_one(pol->coeffs + fmpq_poly_degree(pol));
 
         nf_init(nf, pol);
         nf_clear(nf);
 
+        nf_init(nf, pol);
         fmpq_poly_clear(pol);
+        nf_clear(nf);
+    }
+
+    /* random */
+    for (i = 0; i < 500 * antic_test_multiplier(); i++)
+    {
+        nf_t nf;
+
+        nf_init_randtest(nf, state,
+                2 + n_randint(state, 50),
+                1 + n_randint(state, 200));
+        nf_clear(nf);
+
+        nf_init_randtest(nf, state,
+                2 + n_randint(state, 50),
+                1 + n_randint(state, 200));
+        nf_clear(nf);
     }
 
     flint_randclear(state);
-    flint_cleanup();
     flint_printf("PASS\n");
     return 0;
 }

--- a/nf_elem.h
+++ b/nf_elem.h
@@ -862,7 +862,7 @@ void nf_elem_mul_gen(nf_elem_t a, const nf_elem_t b, const nf_t nf)
   {
       fmpz * den = LNF_ELEM_DENREF(a);
 	    fmpz * num = LNF_ELEM_NUMREF(a);
-      _fmpq_mul(num, den, LNF_ELEM_NUMREF(b), LNF_ELEM_DENREF(b), fmpq_poly_numref(nf->pol), fmpq_poly_denref(nf->pol));
+      _fmpq_mul(num, den, LNF_ELEM_NUMREF(b), LNF_ELEM_DENREF(b), fmpq_poly_numref(nf->pol), fmpq_poly_numref(nf->pol) + 1);
       _fmpq_canonicalise(num, den);
       fmpz_neg(num, num);
   }

--- a/nf_elem/test/t-add_sub.c
+++ b/nf_elem/test/t-add_sub.c
@@ -11,6 +11,7 @@
 /******************************************************************************
 
     Copyright (C) 2013 William Hart
+                  2020 Julian Rüth
 
 ******************************************************************************/
 
@@ -32,16 +33,10 @@ main(void)
     /* test b + c - c = b */
     for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
-        fmpq_poly_t pol;
         nf_t nf;
         nf_elem_t a, b, c, t;
 
-        fmpq_poly_init(pol);
-        do {
-           fmpq_poly_randtest_not_zero(pol, state, 40, 200);
-        } while (fmpq_poly_degree(pol) < 1);
-
-        nf_init(nf, pol);
+        nf_init_randtest(nf, state, 40, 200);
 
         nf_elem_init(a, nf);
         nf_elem_init(b, nf);
@@ -70,23 +65,15 @@ main(void)
         nf_elem_clear(t, nf);
          
         nf_clear(nf);
-
-        fmpq_poly_clear(pol);
     }
     
     /* test b + c - c = b : exercise common denominator path */
     for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
-        fmpq_poly_t pol;
         nf_t nf;
         nf_elem_t a, b, c, t;
 
-        fmpq_poly_init(pol);
-        do {
-           fmpq_poly_randtest_not_zero(pol, state, 3, 200);
-        } while (fmpq_poly_degree(pol) < 1);
-
-        nf_init(nf, pol);
+        nf_init_randtest(nf, state, 3, 200);
 
         nf_elem_init(a, nf);
         nf_elem_init(b, nf);
@@ -118,23 +105,15 @@ main(void)
         nf_elem_clear(t, nf);
          
         nf_clear(nf);
-
-        fmpq_poly_clear(pol);
     }
     
     /* test aliasing a and b */
     for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
-        fmpq_poly_t pol;
         nf_t nf;
         nf_elem_t a, b, c;
 
-        fmpq_poly_init(pol);
-        do {
-           fmpq_poly_randtest_not_zero(pol, state, 40, 200);
-        } while (fmpq_poly_degree(pol) < 1);
-
-        nf_init(nf, pol);
+        nf_init_randtest(nf, state, 40, 200);
 
         nf_elem_init(a, nf);
         nf_elem_init(b, nf);
@@ -162,23 +141,15 @@ main(void)
         nf_elem_clear(c, nf);
          
         nf_clear(nf);
-
-        fmpq_poly_clear(pol);
     }
 
     /* test aliasing a and c */
     for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
-        fmpq_poly_t pol;
         nf_t nf;
         nf_elem_t a, b, c;
 
-        fmpq_poly_init(pol);
-        do {
-           fmpq_poly_randtest_not_zero(pol, state, 40, 200);
-        } while (fmpq_poly_degree(pol) < 1);
-
-        nf_init(nf, pol);
+        nf_init_randtest(nf, state, 40, 200);
 
         nf_elem_init(a, nf);
         nf_elem_init(b, nf);
@@ -206,8 +177,6 @@ main(void)
         nf_elem_clear(c, nf);
          
         nf_clear(nf);
-
-        fmpq_poly_clear(pol);
     }
 
     flint_randclear(state);

--- a/nf_elem/test/t-div.c
+++ b/nf_elem/test/t-div.c
@@ -11,6 +11,7 @@
 /******************************************************************************
 
     Copyright (C) 2014 William Hart
+                  2020 Julian Rüth
 
 ******************************************************************************/
 
@@ -32,16 +33,10 @@ main(void)
     /* test a*^-1 = 1 */
     for (i = 0; i < 10*antic_test_multiplier(); i++)
     {
-        fmpq_poly_t pol;
         nf_t nf;
         nf_elem_t a, b, c;
 
-        fmpq_poly_init(pol);
-        do {
-           fmpq_poly_randtest_not_zero(pol, state, 25, 100);
-        } while (fmpq_poly_degree(pol) < 1);
-   
-        nf_init(nf, pol);
+        nf_init_randtest(nf, state, 25, 100);
         
         nf_elem_init(a, nf);
         nf_elem_init(b, nf);
@@ -70,23 +65,15 @@ main(void)
         nf_elem_clear(c, nf);
          
         nf_clear(nf);
-
-        fmpq_poly_clear(pol);
     }
     
     /* test aliasing a and b */
     for (i = 0; i < 10 * antic_test_multiplier(); i++)
     {
-        fmpq_poly_t pol;
         nf_t nf;
         nf_elem_t a, b, c;
 
-        fmpq_poly_init(pol);
-        do {
-           fmpq_poly_randtest_not_zero(pol, state, 25, 100);
-        } while (fmpq_poly_degree(pol) < 1);
-
-        nf_init(nf, pol);
+        nf_init_randtest(nf, state, 25, 100);
 
         nf_elem_init(a, nf);
         nf_elem_init(b, nf);
@@ -114,8 +101,6 @@ main(void)
         nf_elem_clear(b, nf);
          
         nf_clear(nf);
-
-        fmpq_poly_clear(pol);
     }
 
     /* test aliasing a and c */

--- a/nf_elem/test/t-equal_fmpz_fmpq.c
+++ b/nf_elem/test/t-equal_fmpz_fmpq.c
@@ -11,6 +11,7 @@
 /******************************************************************************
 
     Copyright (C) 2018 Vincent Delecroix
+                  2020 Julian Rüth
 
 ******************************************************************************/
 
@@ -32,7 +33,6 @@ int main(void)
 
     for (i = 0; i < 1000 * antic_test_multiplier(); i++)
     {
-        fmpq_poly_t pol;
         fmpz_t z;
         fmpq_t q;
         fmpq_poly_t f;
@@ -43,17 +43,13 @@ int main(void)
         fmpq_init(q);
         fmpz_init(z);
 
-        fmpq_poly_init(pol);
-        do {
-           fmpq_poly_randtest_not_zero(pol, state, 20, 200);
-        } while (fmpq_poly_degree(pol) < 1);
+        nf_init_randtest(nf, state, 20, 200);
 
-        nf_init(nf, pol);
         nf_elem_init(a, nf);
 
         fmpq_poly_init(f);
 
-        fmpq_poly_randtest(f, state, fmpq_poly_degree(pol) - 1, 200);
+        fmpq_poly_randtest(f, state, fmpq_poly_degree(nf->pol) - 1, 200);
         nf_elem_set_fmpq_poly(a, f, nf);
 
         fmpq_poly_get_coeff_fmpq(q, f, 0);
@@ -100,7 +96,6 @@ int main(void)
                 abort();
         }
 
-        fmpq_poly_clear(pol);
         fmpq_poly_clear(f);
         nf_elem_clear(a, nf);
         nf_clear(nf);

--- a/nf_elem/test/t-get_fmpz_mod_poly.c
+++ b/nf_elem/test/t-get_fmpz_mod_poly.c
@@ -11,6 +11,7 @@
 /******************************************************************************
 
   Copyright (C) 2018 Tommy Hofmann
+                2020 Julian Rüth
 
  ******************************************************************************/
 
@@ -32,7 +33,6 @@ main(void)
     for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
         slong j;
-        fmpq_poly_t pol;
         nf_t nf;
         nf_elem_t a;
         fmpz_mod_poly_t reduced_elem;
@@ -46,12 +46,7 @@ main(void)
         fmpz_init(reduced_coeff);
         fmpz_mod_poly_init(reduced_elem, mod);
 
-        fmpq_poly_init(pol);
-        do {
-            fmpq_poly_randtest_not_zero(pol, state, 40, 200);
-        } while (fmpq_poly_degree(pol) < 1);
-
-        nf_init(nf, pol);
+        nf_init_randtest(nf, state, 40, 200);
 
         nf_elem_init(a, nf);
 
@@ -59,7 +54,7 @@ main(void)
 
         nf_elem_get_fmpz_mod_poly_den(reduced_elem, a, nf, 0);
 
-        for (j = 0; j < fmpq_poly_degree(pol); j++)
+        for (j = 0; j < fmpq_poly_degree(nf->pol); j++)
         {
             nf_elem_get_coeff_fmpz(coeff, a, j, nf);
             fmpz_mod(coeff, coeff, mod);
@@ -68,7 +63,7 @@ main(void)
             if (!result)
             {
                 printf("FAIL: Reducing without denominator\n");
-                printf("f = "); fmpq_poly_print_pretty(pol, "x"); printf("\n");
+                printf("f = "); fmpq_poly_print_pretty(nf->pol, "x"); printf("\n");
                 printf("a = "); nf_elem_print_pretty(a, nf, "x"); printf("\n");
                 printf("n = "); fmpz_print(mod); printf("\n");
                 printf("a mod n = "); fmpz_mod_poly_print_pretty(reduced_elem, "x"); printf("\n");
@@ -81,13 +76,11 @@ main(void)
         fmpz_clear(coeff);
         fmpz_clear(mod);
         nf_clear(nf);
-        fmpq_poly_clear(pol);
     }
 
     for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
         slong j;
-        fmpq_poly_t pol;
         nf_t nf;
         nf_elem_t a;
         fmpz_mod_poly_t reduced_elem;
@@ -106,12 +99,7 @@ main(void)
 
         fmpz_mod_poly_init(reduced_elem, mod);
 
-        fmpq_poly_init(pol);
-        do {
-            fmpq_poly_randtest_not_zero(pol, state, 40, 200);
-        } while (fmpq_poly_degree(pol) < 1);
-
-        nf_init(nf, pol);
+        nf_init_randtest(nf, state, 40, 200);
 
         nf_elem_init(a, nf);
 
@@ -124,7 +112,7 @@ main(void)
 
         nf_elem_get_fmpz_mod_poly(reduced_elem, a, nf);
 
-        for (j = 0; j < fmpq_poly_degree(pol); j++)
+        for (j = 0; j < fmpq_poly_degree(nf->pol); j++)
         {
             nf_elem_get_coeff_fmpz(coeff, a, j, nf);
             nf_elem_get_den(den, a, nf);
@@ -152,7 +140,6 @@ main(void)
         nf_elem_clear(a, nf);
         fmpz_mod_poly_clear(reduced_elem);
         nf_clear(nf);
-        fmpq_poly_clear(pol);
     }
 
     flint_randclear(state);

--- a/nf_elem/test/t-get_nmod_poly.c
+++ b/nf_elem/test/t-get_nmod_poly.c
@@ -11,6 +11,7 @@
 /******************************************************************************
 
     Copyright (C) 2018 Tommy Hofmann
+                  2020 Julian Rüth
 
 ******************************************************************************/
 
@@ -32,7 +33,6 @@ main(void)
     for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
         slong j;
-        fmpq_poly_t pol;
         nf_t nf;
         nf_elem_t a;
         nmod_poly_t reduced_elem;
@@ -44,12 +44,7 @@ main(void)
         fmpz_init(coeff);
         nmod_poly_init(reduced_elem, mod);
 
-        fmpq_poly_init(pol);
-        do {
-            fmpq_poly_randtest_not_zero(pol, state, 40, 200);
-        } while (fmpq_poly_degree(pol) < 1);
-
-        nf_init(nf, pol);
+        nf_init_randtest(nf, state, 40, 200);
 
         nf_elem_init(a, nf);
 
@@ -57,7 +52,7 @@ main(void)
 
         nf_elem_get_nmod_poly_den(reduced_elem, a, nf, 0);
 
-        for (j = 0; j < fmpq_poly_degree(pol); j++)
+        for (j = 0; j < fmpq_poly_degree(nf->pol); j++)
         {
             nf_elem_get_coeff_fmpz(coeff, a, j, nf);
             result = (nmod_poly_get_coeff_ui(reduced_elem, j) == fmpz_fdiv_ui(coeff, mod));
@@ -76,14 +71,11 @@ main(void)
         fmpz_clear(coeff);
 
         nf_clear(nf);
-
-        fmpq_poly_clear(pol);
     }
 
     for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
         slong j;
-        fmpq_poly_t pol;
         nf_t nf;
         nf_elem_t a;
         nmod_poly_t reduced_elem;
@@ -99,12 +91,7 @@ main(void)
 
         nmod_poly_init(reduced_elem, mod);
 
-        fmpq_poly_init(pol);
-        do {
-            fmpq_poly_randtest_not_zero(pol, state, 40, 200);
-        } while (fmpq_poly_degree(pol) < 1);
-
-        nf_init(nf, pol);
+        nf_init_randtest(nf, state, 40, 200);
 
         nf_elem_init(a, nf);
 
@@ -116,7 +103,7 @@ main(void)
 
         nf_elem_get_nmod_poly(reduced_elem, a, nf);
 
-        for (j = 0; j < fmpq_poly_degree(pol); j++)
+        for (j = 0; j < fmpq_poly_degree(nf->pol); j++)
         {
             nf_elem_get_coeff_fmpz(coeff, a, j, nf);
             d_modinv = n_invmod(d_mod, mod);
@@ -136,7 +123,6 @@ main(void)
         nf_elem_clear(a, nf);
         nmod_poly_clear(reduced_elem);
         nf_clear(nf);
-        fmpq_poly_clear(pol);
     }
 
     flint_randclear(state);

--- a/nf_elem/test/t-get_set_den.c
+++ b/nf_elem/test/t-get_set_den.c
@@ -11,6 +11,7 @@
 /******************************************************************************
 
     Copyright (C) 2013 William Hart
+                  2020 Julian Rüth
 
 ******************************************************************************/
 
@@ -31,19 +32,14 @@ main(void)
 
     for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
-        fmpq_poly_t pol;
         nf_t nf;
         nf_elem_t a;
         fmpz_t d, d2;
 
-        fmpq_poly_init(pol);
-        do {
-           fmpq_poly_randtest_not_zero(pol, state, 40, 200);
-        } while (fmpq_poly_degree(pol) < 1);
+        nf_init_randtest(nf, state, 40, 200);
 
         fmpz_init(d);
         fmpz_init(d2);
-        nf_init(nf, pol);
 
         nf_elem_init(a, nf);
         nf_elem_randtest(a, state, 200, nf);
@@ -69,8 +65,6 @@ main(void)
 
         fmpz_clear(d);
         fmpz_clear(d2);
-
-        fmpq_poly_clear(pol);
     }
 
     flint_randclear(state);

--- a/nf_elem/test/t-get_set_fmpq_poly.c
+++ b/nf_elem/test/t-get_set_fmpq_poly.c
@@ -11,6 +11,7 @@
 /******************************************************************************
 
     Copyright (C) 2013 William Hart
+                  2020 Julian Rüth
 
 ******************************************************************************/
 
@@ -31,23 +32,17 @@ main(void)
 
     for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
-        fmpq_poly_t pol;
         fmpq_poly_t f;
         fmpq_poly_t g;
         nf_t nf;
         nf_elem_t a;
 
-        fmpq_poly_init(pol);
         fmpq_poly_init(f);
         fmpq_poly_init(g);
 
-        do {
-           fmpq_poly_randtest_not_zero(pol, state, 40, 200);
-        } while (fmpq_poly_degree(pol) < 1);
+        nf_init_randtest(nf, state, 40, 200);
 
-        nf_init(nf, pol);
-
-        fmpq_poly_randtest(f, state, fmpq_poly_degree(pol) - 1, 200);
+        fmpq_poly_randtest(f, state, fmpq_poly_degree(nf->pol) - 1, 200);
 
         nf_elem_init(a, nf);
         nf_elem_set_fmpq_poly(a, f, nf);
@@ -69,7 +64,6 @@ main(void)
         
         nf_clear(nf);
 
-        fmpq_poly_clear(pol);
         fmpq_poly_clear(f);
         fmpq_poly_clear(g);
     }

--- a/nf_elem/test/t-get_set_fmpz_mat_row.c
+++ b/nf_elem/test/t-get_set_fmpz_mat_row.c
@@ -11,6 +11,7 @@
 /******************************************************************************
 
     Copyright (C) 2013 William Hart
+                  2020 Julian Rüth
 
 ******************************************************************************/
 
@@ -31,23 +32,17 @@ main(void)
 
     for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
-        fmpq_poly_t pol;
         nf_t nf;
         nf_elem_t a, b;
         fmpz_mat_t mat;
         slong rows, j;
         fmpz_t d;
 
-        fmpq_poly_init(pol);
-        do {
-           fmpq_poly_randtest_not_zero(pol, state, 40, 200);
-        } while (fmpq_poly_degree(pol) < 1);
-
-        nf_init(nf, pol);
+        nf_init_randtest(nf, state, 40, 200);
 
         rows = n_randint(state, 100) + 1;
         j = n_randint(state, rows);
-        fmpz_mat_init(mat, rows, fmpq_poly_degree(pol));
+        fmpz_mat_init(mat, rows, fmpq_poly_degree(nf->pol));
 
         nf_elem_init(a, nf);
         nf_elem_init(b, nf);
@@ -63,7 +58,7 @@ main(void)
         if (!result)
         {
            flint_printf("FAIL:\n");
-           flint_printf("rows = %wd, cols = %wd, j = %wd\n", rows, fmpq_poly_degree(pol), j);
+           flint_printf("rows = %wd, cols = %wd, j = %wd\n", rows, fmpq_poly_degree(nf->pol), j);
            flint_printf("a = "); nf_elem_print_pretty(a, nf, "x"); printf("\n");
            flint_printf("b = "); nf_elem_print_pretty(b, nf, "x"); printf("\n");
            flint_printf("d = "); fmpz_print(d); printf("\n");
@@ -78,8 +73,6 @@ main(void)
         fmpz_clear(d);
 
         nf_clear(nf);
-
-        fmpq_poly_clear(pol);
     }
 
     flint_randclear(state);

--- a/nf_elem/test/t-init_clear.c
+++ b/nf_elem/test/t-init_clear.c
@@ -11,6 +11,7 @@
 /******************************************************************************
 
     Copyright (C) 2013 William Hart
+                  2020 Julian Rüth
 
 ******************************************************************************/
 
@@ -31,24 +32,16 @@ main(void)
 
     for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
-        fmpq_poly_t pol;
         nf_t nf;
         nf_elem_t a;
 
-        fmpq_poly_init(pol);
-        do {
-           fmpq_poly_randtest_not_zero(pol, state, 40, 200);
-        } while (fmpq_poly_degree(pol) < 1);
-
-        nf_init(nf, pol);
+        nf_init_randtest(nf, state, 40, 200);
 
         nf_elem_init(a, nf);
         nf_elem_randtest(a, state, 200, nf);
         nf_elem_clear(a, nf);
         
         nf_clear(nf);
-
-        fmpq_poly_clear(pol);
     }
 
     flint_randclear(state);

--- a/nf_elem/test/t-inv.c
+++ b/nf_elem/test/t-inv.c
@@ -11,6 +11,7 @@
 /******************************************************************************
 
     Copyright (C) 2014 William Hart
+                  2020 Julian Rüth
 
 ******************************************************************************/
 
@@ -32,16 +33,10 @@ main(void)
     /* test a*^-1 = 1 */
     for (i = 0; i < 10*antic_test_multiplier(); i++)
     {
-        fmpq_poly_t pol;
         nf_t nf;
         nf_elem_t a, ainv, p1;
 
-        fmpq_poly_init(pol);
-        do {
-           fmpq_poly_randtest_not_zero(pol, state, 25, 100);
-        } while (fmpq_poly_degree(pol) < 1);
-   
-        nf_init(nf, pol);
+        nf_init_randtest(nf, state, 25, 100);
         
         nf_elem_init(a, nf);
         nf_elem_init(ainv, nf);
@@ -69,24 +64,15 @@ main(void)
         nf_elem_clear(p1, nf);
          
         nf_clear(nf);
-
-        fmpq_poly_clear(pol);
     }
     
     /* test aliasing a and b */
     for (i = 0; i < 10 * antic_test_multiplier(); i++)
     {
-        fmpq_poly_t pol;
         nf_t nf;
         nf_elem_t a, b;
 
-        fmpq_poly_init(pol);
-
-        do {
-           fmpq_poly_randtest_not_zero(pol, state, 25, 100);
-        } while (fmpq_poly_degree(pol) < 1);
-   
-        nf_init(nf, pol);
+        nf_init_randtest(nf, state, 25, 100);
 
         nf_elem_init(a, nf);
         nf_elem_init(b, nf);
@@ -111,8 +97,6 @@ main(void)
         nf_elem_clear(b, nf);
          
         nf_clear(nf);
-
-        fmpq_poly_clear(pol);
     }
 
     flint_randclear(state);

--- a/nf_elem/test/t-is_rational_integer.c
+++ b/nf_elem/test/t-is_rational_integer.c
@@ -11,6 +11,7 @@
 /******************************************************************************
 
     Copyright (C) 2018 Vincent Delecroix
+                  2020 Julian Rüth
 
 ******************************************************************************/
 
@@ -35,23 +36,17 @@ int main(void)
         int is_int;
         int is_rat;
 
-        fmpq_poly_t pol;
-
         fmpq_poly_t f;
         nf_t nf;
         nf_elem_t a;
 
-        fmpq_poly_init(pol);
-        do {
-           fmpq_poly_randtest_not_zero(pol, state, 20, 200);
-        } while (fmpq_poly_degree(pol) < 1);
+        nf_init_randtest(nf, state, 20, 200);
 
-        nf_init(nf, pol);
         nf_elem_init(a, nf);
 
         fmpq_poly_init(f);
 
-        fmpq_poly_randtest(f, state, fmpq_poly_degree(pol) - 1, 200);
+        fmpq_poly_randtest(f, state, fmpq_poly_degree(nf->pol) - 1, 200);
         nf_elem_set_fmpq_poly(a, f, nf);
 
         is_rat = fmpq_poly_length(f) <= 1;
@@ -68,7 +63,6 @@ int main(void)
             }
 
         nf_elem_clear(a, nf);
-        fmpq_poly_clear(pol);
         fmpq_poly_clear(f);
         nf_clear(nf);
     }

--- a/nf_elem/test/t-mod_fmpz.c
+++ b/nf_elem/test/t-mod_fmpz.c
@@ -8,28 +8,10 @@
     (at your option) any later version. See <http://www.gnu.org/licenses/>.
 
 =============================================================================*/
-/*=============================================================================
-
-  This file is part of ANTIC.
-
-  FLINT is free software; you can redistribute it and/or modify
-  it under the terms of the GNU General Public License as published by
-  the Free Software Foundation; either version 2 of the License, or
-  (at your option) any later version.
-
-  FLINT is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  GNU General Public License for more details.
-
-  You should have received a copy of the GNU General Public License
-  along with FLINT; if not, write to the Free Software
-  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
-
-  =============================================================================*/
 /******************************************************************************
 
   Copyright (C) 2018 Tommy Hofmann
+                2020 Julian Rüth
 
  ******************************************************************************/
 
@@ -51,7 +33,6 @@ main(void)
     for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
         slong j;
-        fmpq_poly_t pol;
         nf_t nf;
         nf_elem_t a, b;
         fmpz_t coeff, mod, reduced_coeff;
@@ -63,12 +44,7 @@ main(void)
         fmpz_init(coeff);
         fmpz_init(reduced_coeff);
 
-        fmpq_poly_init(pol);
-        do {
-            fmpq_poly_randtest_not_zero(pol, state, 40, 200);
-        } while (fmpq_poly_degree(pol) < 1);
-
-        nf_init(nf, pol);
+        nf_init_randtest(nf, state, 40, 200);
 
         nf_elem_init(a, nf);
         nf_elem_init(b, nf);
@@ -77,7 +53,7 @@ main(void)
 
         nf_elem_mod_fmpz_den(b, a, mod, nf, 0);
 
-        for (j = 0; j < fmpq_poly_degree(pol); j++)
+        for (j = 0; j < fmpq_poly_degree(nf->pol); j++)
         {
             nf_elem_get_coeff_fmpz(coeff, a, j, nf);
             fmpz_mod(coeff, coeff, mod);
@@ -86,7 +62,7 @@ main(void)
             if (!result)
             {
                 printf("FAIL: Reducing without denominator\n");
-                printf("f = "); fmpq_poly_print_pretty(pol, "x"); printf("\n");
+                printf("f = "); fmpq_poly_print_pretty(nf->pol, "x"); printf("\n");
                 printf("a = "); nf_elem_print_pretty(a, nf, "x"); printf("\n");
                 printf("n = "); fmpz_print(mod); printf("\n");
                 printf("b = "); nf_elem_print_pretty(b, nf, "x"); printf("\n");
@@ -96,7 +72,7 @@ main(void)
 
         nf_elem_smod_fmpz_den(b, a, mod, nf, 0);
 
-        for (j = 0; j < fmpq_poly_degree(pol); j++)
+        for (j = 0; j < fmpq_poly_degree(nf->pol); j++)
         {
             nf_elem_get_coeff_fmpz(coeff, a, j, nf);
             fmpz_smod(coeff, coeff, mod);
@@ -105,7 +81,7 @@ main(void)
             if (!result)
             {
                 printf("FAIL: Reducing without denominator\n");
-                printf("f = "); fmpq_poly_print_pretty(pol, "x"); printf("\n");
+                printf("f = "); fmpq_poly_print_pretty(nf->pol, "x"); printf("\n");
                 printf("a = "); nf_elem_print_pretty(a, nf, "x"); printf("\n");
                 printf("n = "); fmpz_print(mod); printf("\n");
                 printf("b = "); nf_elem_print_pretty(b, nf, "x"); printf("\n");
@@ -119,13 +95,11 @@ main(void)
         fmpz_clear(reduced_coeff);
         fmpz_clear(mod);
         nf_clear(nf);
-        fmpq_poly_clear(pol);
     }
 
     for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
         slong j;
-        fmpq_poly_t pol;
         nf_t nf;
         nf_elem_t a, b, c;
         fmpz_t coeff, mod, den;
@@ -137,12 +111,7 @@ main(void)
         fmpz_init(coeff);
         fmpz_init(den);
 
-        fmpq_poly_init(pol);
-        do {
-            fmpq_poly_randtest_not_zero(pol, state, 4, 2);
-        } while (fmpq_poly_degree(pol) < 1);
-
-        nf_init(nf, pol);
+        nf_init_randtest(nf, state, 4, 2);
 
         nf_elem_init(a, nf);
         nf_elem_init(b, nf);
@@ -154,7 +123,7 @@ main(void)
 
         nf_elem_sub(c, b, a, nf);
 
-        for (j = 0; j < fmpq_poly_degree(pol); j++)
+        for (j = 0; j < fmpq_poly_degree(nf->pol); j++)
         {
             nf_elem_get_coeff_fmpz(coeff, c, j, nf);
             fmpz_mod(coeff, coeff, mod);
@@ -162,7 +131,7 @@ main(void)
             if (!result || !nf_elem_den_is_one(c, nf))
             {
                 printf("FAIL: Reducing without denominator\n");
-                printf("f = "); fmpq_poly_print_pretty(pol, "x"); printf("\n");
+                printf("f = "); fmpq_poly_print_pretty(nf->pol, "x"); printf("\n");
                 printf("a = "); nf_elem_print_pretty(a, nf, "x"); printf("\n");
                 printf("b = "); nf_elem_print_pretty(b, nf, "x"); printf("\n");
                 printf("c = "); nf_elem_print_pretty(c, nf, "x"); printf("\n");
@@ -175,7 +144,7 @@ main(void)
 
         nf_elem_sub(c, b, a, nf);
 
-        for (j = 0; j < fmpq_poly_degree(pol); j++)
+        for (j = 0; j < fmpq_poly_degree(nf->pol); j++)
         {
             nf_elem_get_coeff_fmpz(coeff, c, j, nf);
             fmpz_smod(coeff, coeff, mod);
@@ -183,7 +152,7 @@ main(void)
             if (!result || !nf_elem_den_is_one(c, nf))
             {
                 printf("FAIL: Reducing without denominator\n");
-                printf("f = "); fmpq_poly_print_pretty(pol, "x"); printf("\n");
+                printf("f = "); fmpq_poly_print_pretty(nf->pol, "x"); printf("\n");
                 printf("a = "); nf_elem_print_pretty(a, nf, "x"); printf("\n");
                 printf("b = "); nf_elem_print_pretty(b, nf, "x"); printf("\n");
                 printf("c = "); nf_elem_print_pretty(c, nf, "x"); printf("\n");
@@ -199,12 +168,10 @@ main(void)
         fmpz_clear(mod);
         fmpz_clear(den);
         nf_clear(nf);
-        fmpq_poly_clear(pol);
     }
 
     for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
-        fmpq_poly_t pol;
         nf_t nf;
         nf_elem_t a, b, c;
         fmpz_t mod, den, gcd;
@@ -216,12 +183,7 @@ main(void)
         fmpz_init(den);
         fmpz_init(gcd);
 
-        fmpq_poly_init(pol);
-        do {
-            fmpq_poly_randtest_not_zero(pol, state, 4, 2);
-        } while (fmpq_poly_degree(pol) < 1);
-
-        nf_init(nf, pol);
+        nf_init_randtest(nf, state, 4, 2);
 
         nf_elem_init(a, nf);
         nf_elem_init(b, nf);
@@ -239,7 +201,7 @@ main(void)
         if (!fmpz_is_one(gcd))
         {
             printf("FAIL: Coprime denominators\n");
-            printf("f = "); fmpq_poly_print_pretty(pol, "x"); printf("\n");
+            printf("f = "); fmpq_poly_print_pretty(nf->pol, "x"); printf("\n");
             printf("a = "); nf_elem_print_pretty(a, nf, "x"); printf("\n");
             printf("b = "); nf_elem_print_pretty(b, nf, "x"); printf("\n");
             printf("c = "); nf_elem_print_pretty(c, nf, "x"); printf("\n");
@@ -254,7 +216,6 @@ main(void)
         fmpz_clear(den);
         fmpz_clear(gcd);
         nf_clear(nf);
-        fmpq_poly_clear(pol);
     }
 
     flint_randclear(state);

--- a/nf_elem/test/t-mul.c
+++ b/nf_elem/test/t-mul.c
@@ -11,6 +11,7 @@
 /******************************************************************************
 
     Copyright (C) 2013 William Hart
+                  2020 Julian Rüth
 
 ******************************************************************************/
 
@@ -32,16 +33,10 @@ main(void)
     /* test a*(b + c) = a*b + a*c */
     for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
-        fmpq_poly_t pol;
         nf_t nf;
         nf_elem_t a, b, c, s, p, p1, p2;
 
-        fmpq_poly_init(pol);
-        do {
-           fmpq_poly_randtest_not_zero(pol, state, 40, 200);
-        } while (fmpq_poly_degree(pol) < 1);
-        
-        nf_init(nf, pol);
+        nf_init_randtest(nf, state, 40, 200);
         
         nf_elem_init(a, nf);
         nf_elem_init(b, nf);
@@ -85,23 +80,15 @@ main(void)
         nf_elem_clear(p2, nf);
          
         nf_clear(nf);
-
-        fmpq_poly_clear(pol);
     }
     
     /* test aliasing a and b */
     for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
-        fmpq_poly_t pol;
         nf_t nf;
         nf_elem_t a, b, c;
 
-        fmpq_poly_init(pol);
-        do {
-           fmpq_poly_randtest_not_zero(pol, state, 40, 200);
-        } while (fmpq_poly_degree(pol) < 1);
-        
-        nf_init(nf, pol);
+        nf_init_randtest(nf, state, 40, 200);
 
         nf_elem_init(a, nf);
         nf_elem_init(b, nf);
@@ -128,24 +115,16 @@ main(void)
         nf_elem_clear(c, nf);
          
         nf_clear(nf);
-
-        fmpq_poly_clear(pol);
     }
 
     /* test aliasing a and c */
     for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
-        fmpq_poly_t pol;
         nf_t nf;
         nf_elem_t a, b, c;
 
-        fmpq_poly_init(pol);
-        do {
-           fmpq_poly_randtest_not_zero(pol, state, 40, 200);
-        } while (fmpq_poly_degree(pol) < 1);
+        nf_init_randtest(nf, state, 40, 200);
         
-        nf_init(nf, pol);
-
         nf_elem_init(a, nf);
         nf_elem_init(b, nf);
         nf_elem_init(c, nf);
@@ -171,8 +150,6 @@ main(void)
         nf_elem_clear(c, nf);
          
         nf_clear(nf);
-
-        fmpq_poly_clear(pol);
     }
 
     flint_randclear(state);

--- a/nf_elem/test/t-mul_gen.c
+++ b/nf_elem/test/t-mul_gen.c
@@ -11,6 +11,7 @@
 /******************************************************************************
 
     Copyright (C) 2018 Tommy Hofmann
+                  2020 Julian Rüth
 
 ******************************************************************************/
 
@@ -32,16 +33,10 @@ main(void)
     /* test mul_gen(b) = a * b, where a is the generator */
     for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
-        fmpq_poly_t pol;
         nf_t nf;
         nf_elem_t a, b, p1, p2;
 
-        fmpq_poly_init(pol);
-        do {
-           fmpq_poly_randtest_not_zero(pol, state, 40, 200);
-        } while (fmpq_poly_degree(pol) < 1);
-        
-        nf_init(nf, pol);
+        nf_init_randtest(nf, state, 40, 200);
         
         nf_elem_init(a, nf);
         nf_elem_init(b, nf);
@@ -73,23 +68,15 @@ main(void)
         nf_elem_clear(p2, nf);
          
         nf_clear(nf);
-
-        fmpq_poly_clear(pol);
     }
     
     /* test aliasing b and b */
     for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
-        fmpq_poly_t pol;
         nf_t nf;
         nf_elem_t b, c;
 
-        fmpq_poly_init(pol);
-        do {
-           fmpq_poly_randtest_not_zero(pol, state, 40, 200);
-        } while (fmpq_poly_degree(pol) < 1);
-        
-        nf_init(nf, pol);
+        nf_init_randtest(nf, state, 40, 200);
 
         nf_elem_init(b, nf);
         nf_elem_init(c, nf);
@@ -112,8 +99,6 @@ main(void)
         nf_elem_clear(c, nf);
          
         nf_clear(nf);
-
-        fmpq_poly_clear(pol);
     }
     
     flint_randclear(state);

--- a/nf_elem/test/t-norm.c
+++ b/nf_elem/test/t-norm.c
@@ -11,6 +11,7 @@
 /******************************************************************************
 
     Copyright (C) 2014 William Hart
+                  2020 Julian Rüth
 
 ******************************************************************************/
 
@@ -32,17 +33,11 @@ main(void)
     /* test norm(a*b) = norm(a)*norm(b) */
     for (i = 0; i < 10 * antic_test_multiplier(); i++)
     {
-        fmpq_poly_t pol;
         nf_t nf;
         nf_elem_t a, b, c;
         fmpq_t anorm, bnorm, cnorm, cnorm2;
 
-        fmpq_poly_init(pol);
-        do {
-           fmpq_poly_randtest_not_zero(pol, state, 25, 200);
-        } while (fmpq_poly_degree(pol) < 1);
-        
-        nf_init(nf, pol);
+        nf_init_randtest(nf, state, 25, 200);
         
         nf_elem_init(a, nf);
         nf_elem_init(b, nf);
@@ -87,8 +82,6 @@ main(void)
         nf_elem_clear(c, nf);
          
         nf_clear(nf);
-
-        fmpq_poly_clear(pol);
     }
     
     flint_randclear(state);

--- a/nf_elem/test/t-pow.c
+++ b/nf_elem/test/t-pow.c
@@ -11,6 +11,7 @@
 /******************************************************************************
 
     Copyright (C) 2013 William Hart
+                  2020 Julian Rüth
 
 ******************************************************************************/
 
@@ -32,17 +33,11 @@ main(void)
     /* test pow(a, e) = e*e*...*e */
     for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
-        fmpq_poly_t pol;
         nf_t nf;
         nf_elem_t a, p1, p2;
         slong exp;
 
-        fmpq_poly_init(pol);
-        do {
-           fmpq_poly_randtest_not_zero(pol, state, 40, 20);
-        } while (fmpq_poly_degree(pol) < 1);
-        
-        nf_init(nf, pol);
+        nf_init_randtest(nf, state, 40, 20);
         
         nf_elem_init(a, nf);
         nf_elem_init(p1, nf);
@@ -74,24 +69,16 @@ main(void)
         nf_elem_clear(p2, nf);
          
         nf_clear(nf);
-
-        fmpq_poly_clear(pol);
     }
     
     /* test aliasing a and res */
     for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
-        fmpq_poly_t pol;
         nf_t nf;
         nf_elem_t a, p1, p2;
         slong exp;
 
-        fmpq_poly_init(pol);
-        do {
-           fmpq_poly_randtest_not_zero(pol, state, 40, 20);
-        } while (fmpq_poly_degree(pol) < 1);
-        
-        nf_init(nf, pol);
+        nf_init_randtest(nf, state, 40, 20);
         
         nf_elem_init(a, nf);
         nf_elem_init(p1, nf);
@@ -121,8 +108,6 @@ main(void)
         nf_elem_clear(p2, nf);
          
         nf_clear(nf);
-
-        fmpq_poly_clear(pol);
     }
     
     flint_randclear(state);

--- a/nf_elem/test/t-rep_mat.c
+++ b/nf_elem/test/t-rep_mat.c
@@ -11,6 +11,7 @@
 /******************************************************************************
 
     Copyright (C) 2018 Tommy Hofmann
+                  2020 Julian Rüth
 
 ******************************************************************************/
 
@@ -33,21 +34,15 @@ main(void)
     /* test mul_gen(b) = a * b, where a is the generator */
     for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
-        fmpq_poly_t pol;
         nf_t nf;
         nf_elem_t a, b, p1, p2, t;
         slong d;
         slong j, k;
         fmpq_mat_t R;
 
-        fmpq_poly_init(pol);
-        do {
-           fmpq_poly_randtest_not_zero(pol, state, 20, 100);
-        } while (fmpq_poly_degree(pol) < 1);
+        nf_init_randtest(nf, state, 20, 100);
 
-        nf_init(nf, pol);
-
-        d = fmpq_poly_degree(pol);
+        d = fmpq_poly_degree(nf->pol);
 
         fmpq_mat_init(R, d, d);
 
@@ -97,8 +92,6 @@ main(void)
         fmpq_mat_clear(R);
 
         nf_clear(nf);
-
-        fmpq_poly_clear(pol);
     }
 
     flint_randclear(state);

--- a/nf_elem/test/t-rep_mat_fmpz_mat_den.c
+++ b/nf_elem/test/t-rep_mat_fmpz_mat_den.c
@@ -11,6 +11,7 @@
 /******************************************************************************
 
     Copyright (C) 2018 Tommy Hofmann
+                  2020 Julian Rüth
 
 ******************************************************************************/
 
@@ -33,7 +34,6 @@ main(void)
     /* test mul_gen(b) = a * b, where a is the generator */
     for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
-        fmpq_poly_t pol;
         nf_t nf;
         nf_elem_t a, b, p1, p2, t;
         slong d;
@@ -41,14 +41,9 @@ main(void)
         fmpz_mat_t R;
         fmpz_t den;
 
-        fmpq_poly_init(pol);
-        do {
-           fmpq_poly_randtest_not_zero(pol, state, 20, 100);
-        } while (fmpq_poly_degree(pol) < 1);
+        nf_init_randtest(nf, state, 20, 100);
 
-        nf_init(nf, pol);
-
-        d = fmpq_poly_degree(pol);
+        d = fmpq_poly_degree(nf->pol);
 
         fmpz_mat_init(R, d, d);
 
@@ -107,8 +102,6 @@ main(void)
         fmpz_clear(den);
 
         nf_clear(nf);
-
-        fmpq_poly_clear(pol);
     }
 
     flint_randclear(state);

--- a/nf_elem/test/t-set_coeff_num_fmpz.c
+++ b/nf_elem/test/t-set_coeff_num_fmpz.c
@@ -11,6 +11,7 @@
 /******************************************************************************
 
     Copyright (C) 2018 Tommy Hofmann
+                  2020 Julian Rüth
 
 ******************************************************************************/
 
@@ -31,30 +32,25 @@ main(void)
 
     for (i = 0; i < 1000 * antic_test_multiplier(); i++)
     {
-        fmpq_poly_t pol;
         nf_t nf;
         nf_elem_t a, b;
         fmpz_t d, d2;
         slong coeff;
         fmpq_t newcoeff, tempcoeff;
 
-        fmpq_poly_init(pol);
-        do {
-           fmpq_poly_randtest_not_zero(pol, state, 40, 200);
-        } while (fmpq_poly_degree(pol) < 1);
+        nf_init_randtest(nf, state, 40, 200);
 
         fmpz_init(d);
         fmpz_init(d2);
         fmpq_init(tempcoeff);
         fmpq_init(newcoeff);
-        nf_init(nf, pol);
 
         nf_elem_init(a, nf);
         nf_elem_init(b, nf);
         nf_elem_randtest(a, state, 200, nf);
         nf_elem_set(b, a, nf);
 
-        coeff = (slong) n_randint(state, fmpq_poly_length(pol));
+        coeff = (slong) n_randint(state, fmpq_poly_length(nf->pol));
         
         fmpz_randtest(d, state, 200);
 
@@ -74,7 +70,7 @@ main(void)
             flint_printf("coeff = %u\n", coeff);
             flint_printf("d = "); fmpz_print(d); printf("\n");
             flint_printf("newcoeff = "); fmpq_print(newcoeff); printf("\n");
-            flint_printf("pol = "); fmpq_poly_print_pretty(pol, "x"); printf("\n");
+            flint_printf("pol = "); fmpq_poly_print_pretty(nf->pol, "x"); printf("\n");
             abort();
         }
 
@@ -88,8 +84,6 @@ main(void)
 
         fmpq_clear(tempcoeff);
         fmpq_clear(newcoeff);
-
-        fmpq_poly_clear(pol);
     }
 
     flint_randclear(state);

--- a/nf_elem/test/t-set_equal.c
+++ b/nf_elem/test/t-set_equal.c
@@ -11,6 +11,7 @@
 /******************************************************************************
 
     Copyright (C) 2013 William Hart
+                  2020 Julian Rüth
 
 ******************************************************************************/
 
@@ -32,16 +33,10 @@ main(void)
     /* set a = b, check a == b */
     for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
-        fmpq_poly_t pol;
         nf_t nf;
         nf_elem_t a, b;
 
-        fmpq_poly_init(pol);
-        do {
-           fmpq_poly_randtest_not_zero(pol, state, 40, 200);
-        } while (fmpq_poly_degree(pol) < 1);
-
-        nf_init(nf, pol);
+        nf_init_randtest(nf, state, 40, 200);
 
         nf_elem_init(a, nf);
         nf_elem_init(b, nf);
@@ -63,23 +58,15 @@ main(void)
         nf_elem_clear(b, nf);
          
         nf_clear(nf);
-
-        fmpq_poly_clear(pol);
     }
 
     /* test aliasing a and b */
     for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
-        fmpq_poly_t pol;
         nf_t nf;
         nf_elem_t a;
 
-        fmpq_poly_init(pol);
-        do {
-           fmpq_poly_randtest_not_zero(pol, state, 40, 200);
-        } while (fmpq_poly_degree(pol) < 1);
-
-        nf_init(nf, pol);
+        nf_init_randtest(nf, state, 40, 200);
 
         nf_elem_init(a, nf);
         
@@ -98,8 +85,6 @@ main(void)
         nf_elem_clear(a, nf);
          
         nf_clear(nf);
-
-        fmpq_poly_clear(pol);
     }
 
     flint_randclear(state);

--- a/nf_elem/test/t-set_equal_si_ui.c
+++ b/nf_elem/test/t-set_equal_si_ui.c
@@ -11,6 +11,7 @@
 /******************************************************************************
 
     Copyright (C) 2018 Vincent Delecroix
+                  2020 Julian Rüth
 
 ******************************************************************************/
 
@@ -32,7 +33,6 @@ int main(void)
 
     for (i = 0; i < 1000 * antic_test_multiplier(); i++)
     {
-        fmpq_poly_t pol;
         fmpq_poly_t f;
         ulong m, n;
         slong sm, sn;
@@ -42,12 +42,8 @@ int main(void)
         nf_elem_t a;
         nf_elem_t b;
 
-        fmpq_poly_init(pol);
-        do {
-           fmpq_poly_randtest_not_zero(pol, state, 20, 200);
-        } while (fmpq_poly_degree(pol) < 1);
+        nf_init_randtest(nf, state, 20, 200);
 
-        nf_init(nf, pol);
         nf_elem_init(a, nf);
         nf_elem_init(b, nf);
 
@@ -73,7 +69,7 @@ int main(void)
             abort();
         }
 
-        fmpq_poly_randtest(f, state, fmpq_poly_degree(pol) - 1, 200);
+        fmpq_poly_randtest(f, state, fmpq_poly_degree(nf->pol) - 1, 200);
         nf_elem_set_fmpq_poly(a, f, nf);
 
         if (fmpq_poly_length(f) == 0)
@@ -134,7 +130,6 @@ int main(void)
 
         /* cleaning */
 
-        fmpq_poly_clear(pol);
         fmpq_poly_clear(f);
         nf_elem_clear(a, nf);
         nf_elem_clear(b, nf);

--- a/nf_elem/test/t-trace.c
+++ b/nf_elem/test/t-trace.c
@@ -11,6 +11,7 @@
 /******************************************************************************
 
     Copyright (C) 2014 William Hart
+                  2020 Julian Rüth
 
 ******************************************************************************/
 
@@ -32,17 +33,11 @@ main(void)
     /* test trace(a + b) = trace(a) + trace(b) */
     for (i = 0; i < 100 * antic_test_multiplier(); i++)
     {
-        fmpq_poly_t pol;
         nf_t nf;
         nf_elem_t a, b, c;
         fmpq_t atrace, btrace, ctrace, ctrace2;
 
-        fmpq_poly_init(pol);
-        do {
-           fmpq_poly_randtest_not_zero(pol, state, 25, 200);
-        } while (fmpq_poly_degree(pol) < 1);
-        
-        nf_init(nf, pol);
+        nf_init_randtest(nf, state, 25, 200);
         
         nf_elem_init(a, nf);
         nf_elem_init(b, nf);
@@ -87,8 +82,6 @@ main(void)
         nf_elem_clear(c, nf);
          
         nf_clear(nf);
-
-        fmpq_poly_clear(pol);
     }
     
     flint_randclear(state);


### PR DESCRIPTION
also fixes a problem in multiplication with the generator when the defining polynomial is linear but not monic.

`nf_init_randtest` has been implemented originally by @videlec as part of e-antic.