### PR TITLE
Add explicit t(void) to function declarations

### DIFF
--- a/nf.h
+++ b/nf.h
@@ -27,7 +27,7 @@
  extern "C" {
 #endif
 
-long int antic_test_multiplier();
+long int antic_test_multiplier(void);
 
 typedef struct {
    fmpq_poly_t pol;  /* defining polynomial */


### PR DESCRIPTION
C prototypes must use (void), because () means unspecified parameter list.

Pulled from https://github.com/flatsurf/antic f4e8a6085d8446666ec56b7e7247c5544aba9e4b .