### PR TITLE
nf_elem_init to the zero element

### DIFF
--- a/nf_elem/doc/nf_elem.txt
+++ b/nf_elem/doc/nf_elem.txt
@@ -23,7 +23,7 @@
 void nf_elem_init(nf_elem_t a, const nf_t nf)
 
     Initialise a number field element to belong to the given number field
-    \code{nf}.
+    \code{nf}. The element is set to zero.
 
 void nf_elem_clear(nf_elem_t a, const nf_t nf)
 

--- a/nf_elem/init.c
+++ b/nf_elem/init.c
@@ -23,6 +23,7 @@ void nf_elem_init(nf_elem_t a, const nf_t nf)
     {
         fmpz_init(LNF_ELEM_NUMREF(a));
         fmpz_init(LNF_ELEM_DENREF(a));
+        fmpz_one(LNF_ELEM_DENREF(a));
     } else if (nf->flag & NF_QUADRATIC)
     {
         fmpz * const anum = QNF_ELEM_NUMREF(a);
@@ -32,6 +33,7 @@ void nf_elem_init(nf_elem_t a, const nf_t nf)
         fmpz_init(anum + 1);
         fmpz_init(anum + 2);
         fmpz_init(aden);
+        fmpz_one(aden);
     }
     else
     {

--- a/nf_elem/test/t-init_clear.c
+++ b/nf_elem/test/t-init_clear.c
@@ -38,6 +38,13 @@ main(void)
         nf_init_randtest(nf, state, 40, 200);
 
         nf_elem_init(a, nf);
+
+        if (!nf_elem_is_zero(a, nf))
+        {
+            flint_printf("FAIL\n");
+            abort();
+        }
+
         nf_elem_randtest(a, state, 200, nf);
         nf_elem_clear(a, nf);
         


### PR DESCRIPTION
nf_elem_init did not set the element to zero. This is confusing since all Flint types have zeroing init methods (I just spent a good 30 minutes scratching my head because of this).