### PR TITLE
Bump default test_multiplier to 10

### DIFF
--- a/nf/test_multiplier.c
+++ b/nf/test_multiplier.c
@@ -32,7 +32,7 @@ long int antic_test_multiplier()
 
         if (s == NULL)
         {
-            _antic_test_multiplier = 1;
+            _antic_test_multiplier = 10;
         }
         else
         {


### PR DESCRIPTION
Should make tests a bit stronger. It still only takes 30 seconds to run the tests with this change, which isn't a big deal (at least when you're used to waiting for Flint's tests to finish :-)).