### PR TITLE
Add automated testing & pip setup

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -1,7 +1,7 @@
 name: Install with pip
 on:
-  push: { branches: [ "master" ] }
-  pull_request: { branches: [ "master" ] }
+  push: { branches: [ "trunk" ] }
+  pull_request: { branches: [ "trunk" ] }
 
 concurrency:
   group: pip-${{ github.ref }}
@@ -13,13 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with: { submodules: recursive }
-      - uses: conda-incubator/setup-miniconda@v2
-        with: { mamba-version: "*", channels: "flatsurf,conda-forge", channel-priority: true, python-version: "3.9" }
-      - name: install dependencies
-        shell: bash -l {0}
-        run: |
-          mamba install -y libflint
-          conda list
       - name: create Antic sdist
         shell: bash -l {0}
         run: |
@@ -62,3 +55,6 @@ jobs:
         run: |
           export EXTRA_SHARED_FLAGS=-Wl,--no-undefined
           ${{ matrix.pip }} install ${{ steps.sdist.outputs.download-path }}/antic*.tar.gz --verbose --no-binary :all:
+
+env:
+  MAKEFLAGS: -j2

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -36,10 +36,13 @@ jobs:
     container: ${{ matrix.container }}
     strategy:
       matrix:
-        container:
-          - sagemath/sagemath-dev:9.3
-          - sagemath/sagemath-dev:9.4
-          - ubuntu:hirsute
+        include:
+        - container: ubuntu:hirsute
+          pip: pip
+        - container: sagemath/sagemath-dev:9.3
+          pip: sage -pip
+        - container: sagemath/sagemath-dev:9.4
+          pip: sage -pip
     steps:
       - name: install dependencies
         shell: bash
@@ -58,4 +61,4 @@ jobs:
         shell: bash
         run: |
           export EXTRA_SHARED_FLAGS=-Wl,--no-undefined
-          pip install ${{ steps.sdist.outputs.download-path }}/antic*.tar.gz --verbose --no-binary :all:
+          ${{ matrix.pip }} install ${{ steps.sdist.outputs.download-path }}/antic*.tar.gz --verbose --no-binary :all:

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: antic-sdist
-          path: dist/
+          path: /tmp/dist/
       - name: install antic
         shell: bash
         run: |

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -1,0 +1,59 @@
+name: Install with pip
+on:
+  push: { branches: [ "master" ] }
+  pull_request: { branches: [ "master" ] }
+
+concurrency:
+  group: pip-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sdist:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with: { submodules: recursive }
+      - uses: conda-incubator/setup-miniconda@v2
+        with: { mamba-version: "*", channels: "flatsurf,conda-forge", channel-priority: true, python-version: "3.9" }
+      - name: install dependencies
+        shell: bash -l {0}
+        run: |
+          mamba install -y libflint
+          conda list
+      - name: create Antic sdist
+        shell: bash -l {0}
+        run: |
+          python setup.py sdist
+      - name: upload Antic sdist
+        uses: actions/upload-artifact@v2
+        with:
+          name: antic-sdist
+          path:
+            dist/**
+  install:
+    needs: sdist
+    runs-on: ubuntu-20.04
+    container: ${{ matrix.container }}
+    strategy:
+      matrix:
+        container:
+          - sagemath/sagemath-dev:9.3
+          - sagemath/sagemath-dev:9.4
+          - ubuntu:hirsute
+    steps:
+      - name: install dependencies
+        shell: bash
+        run: |
+          apt update
+          export DEBIAN_FRONTEND=noninteractive
+          apt install -y pip libgmp-dev libmpfr-dev libflint-dev
+        if: ${{ startswith(matrix.container, 'ubuntu') }}
+      - name: download antic sdist
+        id: sdist
+        uses: actions/download-artifact@v2
+        with:
+          name: antic-sdist
+      - name: install antic
+        shell: bash
+        run: |
+          pip install ${{ steps.sdist.outputs.download-path }}/antic*.tar.gz --verbose --no-binary :all:

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -53,7 +53,9 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: antic-sdist
+          path: dist/
       - name: install antic
         shell: bash
         run: |
+          export EXTRA_SHARED_FLAGS=-Wl,--no-undefined
           pip install ${{ steps.sdist.outputs.download-path }}/antic*.tar.gz --verbose --no-binary :all:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
     strategy:
       matrix:
         on: [ ubuntu-20.04, macos-10.15 ]
+        libflint: [ 2.8.4 ]
     steps:
       - uses: actions/checkout@v2
         with: { submodules: recursive }
@@ -21,7 +22,7 @@ jobs:
       - name: install dependencies
         shell: bash -l {0}
         run: |
-          mamba install -y libflint c-compiler gmp mpfr
+          mamba install -y libflint=${{ matrix.libflint }} c-compiler gmp mpfr
           conda list
       - name: build antic
         shell: bash -l {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: Run Test Suite
+on:
+  push: { branches: [ "trunk" ] }
+  pull_request: { branches: [ "trunk" ] }
+
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ${{ matrix.on }}
+    strategy:
+      matrix:
+        on: [ ubuntu-20.04, macos-10.15 ]
+    steps:
+      - uses: actions/checkout@v2
+        with: { submodules: recursive }
+      - uses: conda-incubator/setup-miniconda@v2
+        with: { mamba-version: "*", channels: "conda-forge", channel-priority: true, python-version: "3.9" }
+      - name: install dependencies
+        shell: bash -l {0}
+        run: |
+          mamba install -y libflint c-compiler gmp mpfr
+          conda list
+      - name: build antic
+        shell: bash -l {0}
+        run: |
+          ./configure --prefix=$CONDA_PREFIX --with-flint=$CONDA_PREFIX --with-gmp=$CONDA_PREFIX --with-mpfr=$CONDA_PREFIX
+          make
+          make install
+          make check
+
+env:
+  MAKEFLAGS: -j2

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,15 @@
+include AUTHORS
+include configure
+include gpl-2.0.txt
+include INSTALL
+include LICENSE
+include Makefile.in
+include Makefile.subdirs
+include NEWS
+include nf_elem.h
+include nf.h
+include qfb.h
+include README
+graft qfb
+graft nf
+graft nf_elem

--- a/configure
+++ b/configure
@@ -510,38 +510,6 @@ if [ -z "$PIC_FLAG" ]; then
    esac
 fi
 
-#test support for thread-local storage
-
-CONFIG_TLS="#define HAVE_TLS 0"
-
-if [ "$TLS" = "1" ]; then
-   mkdir -p build
-   rm -f build/test-tls > /dev/null 2>&1
-   MSG="Testing __thread..."
-   printf "%s" "$MSG"
-   echo "__thread int x = 42; int main(int argc, char ** argv) { return x != 42; }" > build/test-tls.c
-   $CC build/test-tls.c -o ./build/test-tls > /dev/null 2>&1
-   if [ $? -eq 0 ]; then
-      build/test-tls > /dev/null 2>&1
-      if [ $? -eq 0 ]; then
-         printf "%s\n" "yes"
-         CONFIG_TLS="#define HAVE_TLS 1"
-      else
-         printf "%s\n" "no"
-      fi
-      rm -f build/test-tls{,.c}
-   else
-      rm -f build/test-tls.c
-      printf "%s\n" "no"
-   #build-tls can segfault on systems where tls is not available
-   fi 2> /dev/null
-fi
-
-#pthread configuration
-
-CONFIG_PTHREAD="#define HAVE_PTHREAD ${PTHREAD}"
-
-
 #pocess external modules
 
 EXTRA_INC_DIRS="${EXTRA_INC_DIRS} ${EXTENSIONS}"
@@ -578,6 +546,23 @@ done
 lLIBS="-lantic $lLIBS2"
 LIBS2="$LLIBS $lLIBS2"
 LIBS="$LLIBS $lLIBS"
+
+#test support for fmpz_gcd3 from FLINT
+
+mkdir -p build
+rm -f build/test-fmpz-gcd3 > /dev/null 2>&1
+MSG="Testing fmpz_gcd3..."
+printf "%s" "$MSG"
+echo "void fmpz_gcd3(); int main(int, char**) { fmpz_gcd3(); }" > build/test-fmpz-gcd3.c
+$CC build/test-fmpz-gcd3.c -o ./build/test-fmpz-gcd3 > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+   printf "%s\n" "yes"
+   CFLAGS="$CFLAGS -DHAVE_FMPZ_GCD3"
+   rm -f build/test-fmpz-gcd3{,.c}
+else
+   rm -f build/test-fmpz-gcd3.c
+   printf "%s\n" "no"
+fi
 
 #paths for dynamic linker
 

--- a/nf_elem/mul.c
+++ b/nf_elem/mul.c
@@ -56,7 +56,12 @@ void _nf_elem_mul_gaussian(fmpz * anum, fmpz * aden,
    fmpz_mul(aden, bden, cden);
    if (!fmpz_is_one(aden))
    {
+#ifdef HAVE_FMPZ_GCD3
       fmpz_gcd3(t, anum + 0, anum + 1, aden);
+#else
+      fmpz_gcd(t, anum + 0, anum + 1);
+      fmpz_gcd(t, t, aden);
+#endif
       if (!fmpz_is_one(t))
       {
          fmpz_divexact(anum + 0, anum + 0, t);

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 r"""
 Pip-compatible setup instructions for Antic.
 
-Being a C/C++-library with a few dependencies, Antic cannot be sanely
+Being a C library with a few dependencies, Antic cannot be sanely
 installed with pip from binary builds. It should be installed through a proper
 package manager. When this is not possible, it needs to be installed from
 source with configure-make-make-install. However, in some scenarios, hiding

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,188 @@
+r"""
+Pip-compatible setup instructions for Antic.
+
+Being a C/C++-library with a few dependencies, Antic cannot be sanely
+installed with pip from binary builds. It should be installed through a proper
+package manager. When this is not possible, it needs to be installed from
+source with configure-make-make-install. However, in some scenarios, hiding
+this build inside a pip-package is advantageous, e.g., when installing inside a
+SageMath source build or when packages have to be installed with a
+requirements.txt.
+"""
+# ####################################################################
+#  This file is part of Antic.
+#
+#        Copyright (C) 2021 Julian Rüth
+#
+#  Antic is free software: you can redistribute it and/or modify it under the
+#  terms of the GNU Lesser General Public License as published by the Free
+#  Software Foundation, either version 2.1 of the License, or (at your option)
+#  any later version.
+#
+#  Antic is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+#  FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+#  details.
+#
+#  You should have received a copy of the GNU General Public License along with
+#  Antic. If not, see <https://www.gnu.org/licenses/>.
+# ###################################################################
+import os
+import inspect
+import shutil
+from setuptools import setup
+from setuptools.command.install import install
+from distutils.command.build import build
+from setuptools.command.sdist import sdist
+from subprocess import check_call
+from contextlib import contextmanager
+
+
+@contextmanager
+def cwd(path):
+    r"""
+    Change the current working directory to `path` while inside this context.
+    """
+    pwd = os.getcwd()
+    os.chdir(path)
+    try:
+        yield path
+    finally:
+        os.chdir(pwd)
+
+
+class AutotoolsCommand:
+    r"""
+    Helpers that provide variables like the ones available to automake
+    Makefiles.
+    """
+    @property
+    def builddir(self):
+        r"""
+        Return the path of the build directory, equivalent to @builddir@ in automake.
+
+        This property is only available when a build has been invoked as part of this setup.py run.
+        In particular, this is the directory passed with --build-base.
+        Note that "setup.py install" does not accept a --build-base so we have
+        to make sure that this happens to be build/ relative to the current
+        working directory during the install phase since otherwise the install
+        step won't be able to find the assets that have been built by the build
+        step.
+        """
+        if "build" not in self.distribution.command_obj:
+            raise ValueError("There is no build directory since no build is being performed in this invocation of setup.py")
+
+        return self.distribution.command_obj["build"].build_base
+
+    @property
+    def abs_builddir(self):
+        r"""
+        Return the absolute path of the build directory, equivalent to @abs_builddir@ in automake.
+
+        The limitations of `builddir` apply to this property as well.
+        """
+        builddir = self.builddir
+        if not os.path.isabs(builddir):
+            builddir = os.path.join(self.abs_srcdir, builddir)
+
+        return builddir
+
+    @property
+    def destdir(self):
+        r"""
+        Return the installation prefix for this package in site-packages (or the user directory.)
+
+        This is the value that you want to pass to a configure's --prefix flag.
+        Note that naturally this value is only available when setup was asked
+        to install this package. In particular, this is not available when
+        trying to build a wheel.
+
+        As a consequence this value is also not available initially when
+        invoking `pip install` since that tries to build a wheel first. You
+        might want to invoke pip install with `--no-binary :all:` so that pip
+        skips to a regular install where this value is available.
+        """
+        if "install" not in self.distribution.command_obj:
+            raise ValueError("Cannot determine installation prefix in this build which does not install.")
+        return os.path.join(self.distribution.command_obj["install"].install_lib, self.distribution.get_name())
+
+    @property
+    def abs_srcdir(self):
+        r"""
+        Return the absolute path of the source directory, i.e., the directory where this setup.py is.
+
+        This is the equivalent to @abs_srcdir@ in automake.
+        """
+        return os.path.abspath(os.path.dirname(__file__) or ".")
+
+    @property
+    def MAKE(self):
+        r"""
+        Return the name of the make command which might have been overridden by
+        the MAKE environment variable.
+        """
+        return os.getenv("MAKE", "make")
+
+
+class NoBinaryBuild(build):
+    r"""
+    Disables building binary wheels for this package.
+
+    Since such binary wheels are not relocatable because we hard code library
+    paths into our hedaer files so cppyy known where things are located.
+    """
+
+    def run(self):
+        raise NotImplementedError("No binary wheels can be built for Antic currently because the installation prefix is hard-coded in some of its header files. To skip this step when using pip, run with --no-binary :all:")
+
+
+class ConfigureMakeInstall(install, AutotoolsCommand):
+    r"""
+    Builds and installs Antic by running configure and make install.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # We do not perform a separate build since we don't know the prefix during such a build yet.
+        self.skip_build = True
+
+    def run(self):
+        super().run()
+
+        # Perform a build and install into a directory such as
+        # site-packages/antic.
+        with cwd(self.abs_srcdir):
+            check_call([os.path.join(self.abs_srcdir, "configure"), f"--prefix={self.destdir}"])
+            check_call([self.MAKE, "install"])
+
+    def get_outputs(self):
+        r"""
+        Return the installed files/directories so we know how to uninstall Antic again.
+        """
+        return super().get_outputs() + [self.destdir]
+
+
+setup(
+    name='antic',
+    author='the Antic authors',
+    url='https://github.com/wbhart/antic',
+    # We cannot encode all our dependencies since they are mostly not available
+    # as Python packages. Also we want to build with system packages that are
+    # detected by the configure script.
+    install_requires=[],
+    long_description=inspect.cleandoc(r"""
+        Antic is an algebraic number theory library in C.
+
+        We do not recommend to install Antic from PyPI as it has dependencies that are not available on PyPI.
+
+        Please consult Antic's home page for further details: https://github.com/wbhart/antic
+        """),
+    version='0.2.1',
+    license='LGPL 2.1+',
+    license_files=('LICENSE', 'gpl-2.0.txt'),
+    setup_requires=["wheel"],
+    cmdclass={
+        'build': NoBinaryBuild,
+        'install': ConfigureMakeInstall,
+    },
+)

--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,8 @@ class NoBinaryBuild(build):
     """
 
     def run(self):
-        raise NotImplementedError("No binary wheels can be built for Antic currently because the installation prefix is hard-coded in some of its header files. To skip this step when using pip, run with --no-binary :all:")
+        # We don't want to support building wheels since they reference symbols from flint and other libraries that we cannot install in a controlled version with pip.
+        raise NotImplementedError("No binary wheels can be built for Antic currently. To skip this step when using pip, run with --no-binary :all:")
 
 
 class ConfigureMakeInstall(install, AutotoolsCommand):


### PR DESCRIPTION
* Build and run test suite on Ubuntu & macOS against latest released flint. (To test against an unreleased flint, a beta release of flint would have to be created first.)
* Make antic pip installable. It's a bit weird but sometimes convenient to be able to install antic without having to configure && make install. One application would be installation in SageMath, where pip-installing something is much easier for most than having to understand how to build from source.
* Detect whether `fmpz_gcd3` is available and use `fmpz_gcd` instead if it is not available. (To be able to build with a released version of flint.)

#### Dependencies
* [x] https://github.com/conda-forge/libflint-feedstock/pull/25