### PR TITLE
add fmpq_poly_fit_length

### DIFF
--- a/nf_elem/mul.c
+++ b/nf_elem/mul.c
@@ -132,6 +132,7 @@ void _nf_elem_mul_red(nf_elem_t a, const nf_elem_t b,
          return;
       }
 
+      fmpq_poly_fit_length(NF_ELEM(a), plen);
       if (len1 >= len2)
       {
          _fmpz_poly_mul(NF_ELEM_NUMREF(a), NF_ELEM_NUMREF(b), len1,


### PR DESCRIPTION
to allow uninitionalized nf_elem's (where no allocation has happend)
should have no difference at all for the current set-up, but allows
things to improve upstream

In a next round, we can try to change nf_init to NOT allocate...
(by the looks of it, all(?) other nf_elem functions do look after the
allocation already)