### PR TITLE
Replace checking for fmpz_gcd3 by checking FLINT-version

### DIFF
--- a/configure
+++ b/configure
@@ -547,23 +547,6 @@ lLIBS="-lantic $lLIBS2"
 LIBS2="$LLIBS $lLIBS2"
 LIBS="$LLIBS $lLIBS"
 
-#test support for fmpz_gcd3 from FLINT
-
-mkdir -p build
-rm -f build/test-fmpz-gcd3 > /dev/null 2>&1
-MSG="Testing fmpz_gcd3..."
-printf "%s" "$MSG"
-echo "void fmpz_gcd3(); int main(int, char**) { fmpz_gcd3(); }" > build/test-fmpz-gcd3.c
-$CC build/test-fmpz-gcd3.c -o ./build/test-fmpz-gcd3 > /dev/null 2>&1
-if [ $? -eq 0 ]; then
-   printf "%s\n" "yes"
-   CFLAGS="$CFLAGS -DHAVE_FMPZ_GCD3"
-   rm -f build/test-fmpz-gcd3{,.c}
-else
-   rm -f build/test-fmpz-gcd3.c
-   printf "%s\n" "no"
-fi
-
 #paths for dynamic linker
 
 case "$OS" in

--- a/nf_elem/add.c
+++ b/nf_elem/add.c
@@ -112,8 +112,16 @@ void _nf_elem_add_qf(nf_elem_t a, const nf_elem_t b,
 
       if (can && !fmpz_is_one(aden))
       {
-         fmpz_gcd(d, anum, anum + 1);
+#if (                                                           \
+         (__FLINT_VERSION > 2)                                   \
+         ||                                                      \
+         (__FLINT_VERSION >= 2 && __FLINT_VERSION_MINOR >= 8)    \
+    )
+         fmpz_gcd3(d, anum + 0, anum + 1, anum + 2);
+#else
+         fmpz_gcd(d, anum + 0, anum + 1);
          fmpz_gcd(d, d, anum + 2);
+#endif
          if (!fmpz_is_one(d))
          {
             fmpz_gcd(d, d, aden);
@@ -173,8 +181,16 @@ void _nf_elem_add_qf(nf_elem_t a, const nf_elem_t b,
             
             fmpz_init(e);
               
-            fmpz_gcd(e, anum, anum + 1);
+#if (                                                            \
+         (__FLINT_VERSION > 2)                                   \
+         ||                                                      \
+         (__FLINT_VERSION >= 2 && __FLINT_VERSION_MINOR >= 8)    \
+    )
+            fmpz_gcd3(e, anum + 0, anum + 1, anum + 2);
+#else
+            fmpz_gcd(e, anum + 0, anum + 1);
             fmpz_gcd(e, e, anum + 2);
+#endif
             if (!fmpz_is_one(e))
                fmpz_gcd(e, e, d);
             

--- a/nf_elem/mul.c
+++ b/nf_elem/mul.c
@@ -56,7 +56,11 @@ void _nf_elem_mul_gaussian(fmpz * anum, fmpz * aden,
    fmpz_mul(aden, bden, cden);
    if (!fmpz_is_one(aden))
    {
-#ifdef HAVE_FMPZ_GCD3
+#if (                                                           \
+        (__FLINT_VERSION > 2)                                   \
+        ||                                                      \
+        (__FLINT_VERSION >= 2 && __FLINT_VERSION_MINOR >= 8)    \
+    )
       fmpz_gcd3(t, anum + 0, anum + 1, aden);
 #else
       fmpz_gcd(t, anum + 0, anum + 1);

--- a/nf_elem/sub.c
+++ b/nf_elem/sub.c
@@ -111,8 +111,16 @@ void _nf_elem_sub_qf(nf_elem_t a, const nf_elem_t b,
 
       if (can && !fmpz_is_one(aden))
       {
-         fmpz_gcd(d, anum, anum + 1);
+#if (                                                           \
+        (__FLINT_VERSION > 2)                                   \
+        ||                                                      \
+        (__FLINT_VERSION >= 2 && __FLINT_VERSION_MINOR >= 8)    \
+    )
+         fmpz_gcd3(d, anum + 0, anum + 1, anum + 2);
+#else
+         fmpz_gcd(d, anum + 0, anum + 1);
          fmpz_gcd(d, d, anum + 2);
+#endif
          if (!fmpz_is_one(d))
          {
             fmpz_gcd(d, d, aden);
@@ -172,8 +180,16 @@ void _nf_elem_sub_qf(nf_elem_t a, const nf_elem_t b,
             
             fmpz_init(e);
               
-            fmpz_gcd(e, anum, anum + 1);
+#if (                                                           \
+        (__FLINT_VERSION > 2)                                   \
+        ||                                                      \
+        (__FLINT_VERSION >= 2 && __FLINT_VERSION_MINOR >= 8)    \
+    )
+            fmpz_gcd3(e, anum + 0, anum + 1, anum + 2);
+#else
+            fmpz_gcd(e, anum + 0, anum + 1);
             fmpz_gcd(e, e, anum + 2);
+#endif
             if (!fmpz_is_one(e))
                fmpz_gcd(e, e, d);
             

--- a/qfb.h
+++ b/qfb.h
@@ -183,8 +183,16 @@ int qfb_is_primitive(qfb_t f)
 
    fmpz_init(g);
 
+#if (                                                           \
+        (__FLINT_VERSION > 2)                                   \
+        ||                                                      \
+        (__FLINT_VERSION >= 2 && __FLINT_VERSION_MINOR >= 8)    \
+    )
+   fmpz_gcd3(g, f->a, f->b, f->c);
+#else
    fmpz_gcd(g, f->a, f->b);
    fmpz_gcd(g, g, f->c);
+#endif
    res = fmpz_is_pm1(g);
 
    fmpz_clear(g);


### PR DESCRIPTION
Also replace fmpz_gcd where use of fmpz_gcd3 is possible.

Probably not going to pass due to  #74, we'll see.

Resolves #73 