### PR TITLE
Fix wrong reference in nf_elem_den_is_one

### DIFF
--- a/nf_elem.h
+++ b/nf_elem.h
@@ -502,7 +502,7 @@ int nf_elem_den_is_one(const nf_elem_t a, const nf_t nf)
         return fmpz_is_one(QNF_ELEM_DENREF(a));
     } else
     {
-        return fmpz_is_one(LNF_ELEM_DENREF(a));
+        return fmpz_is_one(NF_ELEM_DENREF(a));
     }
 }
 


### PR DESCRIPTION
Used to LNF_DENREF when it was supposed to use NF_DENREF.

Solves #74 