### PR TITLE
Fix library name on macOS

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         include:
-        - container: ubuntu:hirsute
+        - container: ubuntu:jammy
           pip: pip
         - container: sagemath/sagemath-dev:9.3
           pip: sage -pip

--- a/Makefile.in
+++ b/Makefile.in
@@ -164,8 +164,8 @@ install: library
 	mkdir -p $(DESTDIR)$(PREFIX)/include/antic
 	$(AT)if [ "$(ANTIC_SHARED)" -eq "1" ]; then \
 		cp $(ANTIC_LIB) "$(DESTDIR)$(PREFIX)/$(LIBDIR)"; \
-		[[ $(ANTIC_LIB_ALIAS) == $(ANTIC_LIB) ]] || ln -s $(ANTIC_LIB) "$(DESTDIR)$(PREFIX)/$(LIBDIR)/$(ANTIC_LIB_ALIAS)"
-		[[ $(ANTIC_LIB_SONAME) == $(ANTIC_LIB) ]] || ln -s $(ANTIC_LIB) "$(DESTDIR)$(PREFIX)/$(LIBDIR)/$(ANTIC_LIB_SONAME)"
+		[[ $(ANTIC_LIB_ALIAS) == $(ANTIC_LIB) ]] || ln -s $(ANTIC_LIB) "$(DESTDIR)$(PREFIX)/$(LIBDIR)/$(ANTIC_LIB_ALIAS)" \
+		[[ $(ANTIC_LIB_SONAME) == $(ANTIC_LIB) ]] || ln -s $(ANTIC_LIB) "$(DESTDIR)$(PREFIX)/$(LIBDIR)/$(ANTIC_LIB_SONAME)" \
 	fi
 	$(AT)if [ "$(ANTIC_STATIC)" -eq "1" ]; then \
 		cp libantic.a $(DESTDIR)$(PREFIX)/$(LIBDIR); \

--- a/Makefile.in
+++ b/Makefile.in
@@ -164,8 +164,12 @@ install: library
 	mkdir -p $(DESTDIR)$(PREFIX)/include/antic
 	$(AT)if [ "$(ANTIC_SHARED)" -eq "1" ]; then \
 		cp $(ANTIC_LIB) "$(DESTDIR)$(PREFIX)/$(LIBDIR)"; \
-		[[ $(ANTIC_LIB_ALIAS) == $(ANTIC_LIB) ]] || ln -s $(ANTIC_LIB) "$(DESTDIR)$(PREFIX)/$(LIBDIR)/$(ANTIC_LIB_ALIAS)"; \
-		[[ $(ANTIC_LIB_SONAME) == $(ANTIC_LIB) ]] || ln -s $(ANTIC_LIB) "$(DESTDIR)$(PREFIX)/$(LIBDIR)/$(ANTIC_LIB_SONAME)"; \
+		if [ "$(ANTIC_LIB_ALIAS)" = "$(ANTIC_LIB)" ]; then \
+			ln -s $(ANTIC_LIB) "$(DESTDIR)$(PREFIX)/$(LIBDIR)/$(ANTIC_LIB_ALIAS)"; \
+	  fi; \
+		if [ "$(ANTIC_LIB_SONAME)" = "$(ANTIC_LIB)" ]; then \
+			ln -s $(ANTIC_LIB) "$(DESTDIR)$(PREFIX)/$(LIBDIR)/$(ANTIC_LIB_SONAME)"; \
+		fi; \
 	fi
 	$(AT)if [ "$(ANTIC_STATIC)" -eq "1" ]; then \
 		cp libantic.a $(DESTDIR)$(PREFIX)/$(LIBDIR); \

--- a/Makefile.in
+++ b/Makefile.in
@@ -164,8 +164,8 @@ install: library
 	mkdir -p $(DESTDIR)$(PREFIX)/include/antic
 	$(AT)if [ "$(ANTIC_SHARED)" -eq "1" ]; then \
 		cp $(ANTIC_LIB) "$(DESTDIR)$(PREFIX)/$(LIBDIR)"; \
-		[[ $(ANTIC_LIB_ALIAS) == $(ANTIC_LIB) ]] || ln -s $(ANTIC_LIB) "$(DESTDIR)$(PREFIX)/$(LIBDIR)/$(ANTIC_LIB_ALIAS)" \
-		[[ $(ANTIC_LIB_SONAME) == $(ANTIC_LIB) ]] || ln -s $(ANTIC_LIB) "$(DESTDIR)$(PREFIX)/$(LIBDIR)/$(ANTIC_LIB_SONAME)" \
+		[[ $(ANTIC_LIB_ALIAS) == $(ANTIC_LIB) ]] || ln -s $(ANTIC_LIB) "$(DESTDIR)$(PREFIX)/$(LIBDIR)/$(ANTIC_LIB_ALIAS)"; \
+		[[ $(ANTIC_LIB_SONAME) == $(ANTIC_LIB) ]] || ln -s $(ANTIC_LIB) "$(DESTDIR)$(PREFIX)/$(LIBDIR)/$(ANTIC_LIB_SONAME)"; \
 	fi
 	$(AT)if [ "$(ANTIC_STATIC)" -eq "1" ]; then \
 		cp libantic.a $(DESTDIR)$(PREFIX)/$(LIBDIR); \

--- a/Makefile.in
+++ b/Makefile.in
@@ -60,7 +60,7 @@ verbose:
 clean:
 	$(AT)$(foreach dir, $(BUILD_DIRS), BUILD_DIR=../build/$(dir); export BUILD_DIR; MOD_DIR=$(dir); export MOD_DIR; $(MAKE) -f ../Makefile.subdirs -C $(dir) clean || exit $$?;)
 	$(AT)$(foreach ext, $(EXTENSIONS), $(foreach dir, $(patsubst $(ext)/%.h, %, $(wildcard $(ext)/*.h)), BUILD_DIR=$(CURDIR)/build/$(dir); export BUILD_DIR; MOD_DIR=$(dir); export MOD_DIR; $(MAKE) -f $(CURDIR)/Makefile.subdirs -C $(ext)/$(dir) clean || exit $$?;))
-	rm -f $(OBJS) $(LOBJS) $(TESTS) $(PROFS) $(EXMPS) $(wildcard $(ANTIC_LIBNAME)*) libantic.a
+	rm -f $(OBJS) $(LOBJS) $(TESTS) $(PROFS) $(EXMPS) $(ANTIC_LIB) libantic.a
 	rm -rf build
 
 distclean: clean
@@ -99,8 +99,6 @@ $(ANTIC_LIB): $(LOBJS) $(LIB_SOURCES) $(EXT_SOURCES) $(HEADERS) $(EXT_HEADERS) |
 	-$(AT)if [ "$(ANTIC_SOLIB)" -eq "1" ]; then \
 		$(LDCONFIG) -n "$(CURDIR)"; \
 	fi
-	ln -sf "$(ANTIC_LIB)" "$(ANTIC_LIBNAME)"; \
-	ln -sf "$(ANTIC_LIB)" "$(ANTIC_LIBNAME).$(ANTIC_MAJOR)"; \
 
 libantic.a: $(OBJS) $(LIB_SOURCES) $(EXT_SOURCES) $(HEADERS) $(EXT_HEADERS) | build build/interfaces
 	$(AT)$(foreach ext, $(EXTENSIONS), $(foreach dir, $(patsubst $(ext)/%.h, %, $(wildcard $(ext)/*.h)), mkdir -p build/$(dir); BUILD_DIR=$(CURDIR)/build/$(dir); export BUILD_DIR; MOD_DIR=$(dir); export MOD_DIR; $(MAKE) -f $(CURDIR)/Makefile.subdirs -C $(ext)/$(dir) static || exit $$?;))
@@ -166,7 +164,8 @@ install: library
 	mkdir -p $(DESTDIR)$(PREFIX)/include/antic
 	$(AT)if [ "$(ANTIC_SHARED)" -eq "1" ]; then \
 		cp $(ANTIC_LIB) "$(DESTDIR)$(PREFIX)/$(LIBDIR)"; \
-		cp -a $(shell ls $(ANTIC_LIBNAME)*) "$(DESTDIR)$(PREFIX)/$(LIBDIR)"; \
+		[[ $(ANTIC_LIB_ALIAS) == $(ANTIC_LIB) ]] || ln -s $(ANTIC_LIB) "$(DESTDIR)$(PREFIX)/$(LIBDIR)/$(ANTIC_LIB_ALIAS)"
+		[[ $(ANTIC_LIB_SONAME) == $(ANTIC_LIB) ]] || ln -s $(ANTIC_LIB) "$(DESTDIR)$(PREFIX)/$(LIBDIR)/$(ANTIC_LIB_SONAME)"
 	fi
 	$(AT)if [ "$(ANTIC_STATIC)" -eq "1" ]; then \
 		cp libantic.a $(DESTDIR)$(PREFIX)/$(LIBDIR); \

--- a/configure
+++ b/configure
@@ -383,7 +383,7 @@ if [ -z "$ANTIC_LIB" ]; then
       Darwin)
          ANTIC_LIBNAME="libantic.dylib"
          ANTIC_LIB="libantic.$ANTIC_MAJOR.dylib"
-         EXTRA_SHARED_FLAGS="-install_name $PREFIX/lib/$ANTIC_LIB -compatibility_version $ANTIC_MAJOR -current_version $ANTIC_MAJOR.$ANTIC_MINOR.$ANTIC_PATCH";;
+         EXTRA_SHARED_FLAGS="-install_name $PREFIX/lib/$ANTIC_LIB -compatibility_version $ANTIC_MAJOR.$ANTIC_MINOR -current_version $ANTIC_MAJOR.$ANTIC_MINOR.$ANTIC_PATCH";;
       CYGWIN* | MINGW*)
          ANTIC_LIBNAME="libantic.dll"
          ANTIC_LIB="libantic-$ANTIC_MAJOR.dll"

--- a/configure
+++ b/configure
@@ -382,17 +382,17 @@ if [ -z "$ANTIC_LIB" ]; then
    case "$OS" in
       Darwin)
          ANTIC_LIBNAME="libantic.dylib"
-	 ANTIC_LIB="libantic-$ANTIC_MAJOR.$ANTIC_MINOR.$ANTIC_PATCH.dylib"
+         ANTIC_LIB="libantic.$ANTIC_MAJOR.dylib"
          EXTRA_SHARED_FLAGS="-install_name $PREFIX/lib/$ANTIC_LIB -compatibility_version $ANTIC_MAJOR.$ANTIC_MINOR -current_version $ANTIC_MAJOR.$ANTIC_MINOR.$ANTIC_PATCH";;
       CYGWIN* | MINGW*)
          ANTIC_LIBNAME="libantic.dll"
-	 ANTIC_LIB="libantic-$ANTIC_MAJOR.dll"
-	 EXTRA_SHARED_FLAGS="-static-libgcc -shared -Wl,--export-all-symbols -Wl,-soname,libantic-$ANTIC_MAJOR.dll.$ANTIC_MINOR.$ANTIC_PATCH";;
+         ANTIC_LIB="libantic-$ANTIC_MAJOR.dll"
+         EXTRA_SHARED_FLAGS="-static-libgcc -shared -Wl,--export-all-symbols -Wl,-soname,libantic-$ANTIC_MAJOR.dll.$ANTIC_MINOR.$ANTIC_PATCH";;
       *)
          ANTIC_LIBNAME="libantic.so"
-	 ANTIC_LIB="libantic.so.$ANTIC_MAJOR.$ANTIC_MINOR.$ANTIC_PATCH"
-	 EXTRA_SHARED_FLAGS="-Wl,-soname,libantic.so.$ANTIC_MAJOR"
-	 ANTIC_SOLIB=1;;
+         ANTIC_LIB="libantic.so.$ANTIC_MAJOR.$ANTIC_MINOR.$ANTIC_PATCH"
+         EXTRA_SHARED_FLAGS="-Wl,-soname,libantic.so.$ANTIC_MAJOR"
+         ANTIC_SOLIB=1;;
    esac
    EXTRA_SHARED_FLAGS="${EXTRA_SHARED_FLAGS} -Wl,-rpath,${GMP_LIB_DIR} -Wl,-rpath,${MPFR_LIB_DIR} -Wl,-rpath,${FLINT_LIB_DIR}"
 fi

--- a/configure
+++ b/configure
@@ -383,7 +383,7 @@ if [ -z "$ANTIC_LIB" ]; then
       Darwin)
          ANTIC_LIBNAME="libantic.dylib"
          ANTIC_LIB="libantic.$ANTIC_MAJOR.dylib"
-         EXTRA_SHARED_FLAGS="-install_name $PREFIX/lib/$ANTIC_LIB -compatibility_version $ANTIC_MAJOR.$ANTIC_MINOR -current_version $ANTIC_MAJOR.$ANTIC_MINOR.$ANTIC_PATCH";;
+         EXTRA_SHARED_FLAGS="-install_name $PREFIX/lib/$ANTIC_LIB -compatibility_version $ANTIC_MAJOR -current_version $ANTIC_MAJOR.$ANTIC_MINOR.$ANTIC_PATCH";;
       CYGWIN* | MINGW*)
          ANTIC_LIBNAME="libantic.dll"
          ANTIC_LIB="libantic-$ANTIC_MAJOR.dll"

--- a/configure
+++ b/configure
@@ -5,17 +5,7 @@
 # (C) 2012, William Hart, Jean-Pierre Flori, Thomas DuBuisson
 # (C) 2012, Jan Engelhardt
 # (C) 2017, Vincent Delecroix
-
-# soname version
-#
-# antic   => soname
-# 0.0.1   => 0.0.0
-# 0.2.0   => 0.0.0
-# 0.2.1   => 0.0.0
-# 0.2.2   => 0.0.0
-# 0.2.3   => 0.0.0
-# 0.2.4   => 0.2.4 
-# 0.2.5   => 0.2.5
+# (C) 2022, Julian Rüth
 
 ANTIC_MAJOR=0
 ANTIC_MINOR=2
@@ -375,23 +365,29 @@ fi
 
 echo "Configuring...${MACHINE}-${OS}"
 
-#name for ANTIC shared library
+# Filenames for the ANTIC shared library:
+# ANTIC_LIB: the name of the shared library that we compile to
+# ANTIC_LIB_ALIAS: a short alias of this library that symlinks to ANTIC_LIB
+# ANTIC_LIB_SONAME: the soname of this library that symlinks to ANTIC_LIB
 
 ANTIC_SOLIB=0
 if [ -z "$ANTIC_LIB" ]; then
    case "$OS" in
       Darwin)
-         ANTIC_LIBNAME="libantic.dylib"
-         ANTIC_LIB="libantic.$ANTIC_MAJOR.dylib"
+         ANTIC_LIB="libantic.$ANTIC_MAJOR.$ANTIC_MINOR.$ANTIC_PATCH.dylib"
+         ANTIC_LIB_ALIAS="libantic.dylib"
+         ANTIC_LIB_SONAME="libantic.$ANTIC_MAJOR.$ANTIC_MINOR.dylib"
          EXTRA_SHARED_FLAGS="-install_name $PREFIX/lib/$ANTIC_LIB -compatibility_version $ANTIC_MAJOR.$ANTIC_MINOR -current_version $ANTIC_MAJOR.$ANTIC_MINOR.$ANTIC_PATCH";;
       CYGWIN* | MINGW*)
-         ANTIC_LIBNAME="libantic.dll"
-         ANTIC_LIB="libantic-$ANTIC_MAJOR.dll"
-         EXTRA_SHARED_FLAGS="-static-libgcc -shared -Wl,--export-all-symbols -Wl,-soname,libantic-$ANTIC_MAJOR.dll.$ANTIC_MINOR.$ANTIC_PATCH";;
+         ANTIC_LIB="libantic-$ANTIC_MAJOR.$ANTIC_MINOR.dll"
+         ANTIC_LIB_ALIAS=$ANTIC_LIB
+         ANTIC_LIB_SONAME=$ANTIC_LIB
+         EXTRA_SHARED_FLAGS="-static-libgcc -shared -Wl,--export-all-symbols -Wl,-soname,$ANTIC_LIB_SONAME";;
       *)
-         ANTIC_LIBNAME="libantic.so"
          ANTIC_LIB="libantic.so.$ANTIC_MAJOR.$ANTIC_MINOR.$ANTIC_PATCH"
-         EXTRA_SHARED_FLAGS="-Wl,-soname,libantic.so.$ANTIC_MAJOR"
+         ANTIC_LIB_ALIAS="libantic.so"
+         ANTIC_LIB_SONAME="libantic.so.$ANTIC_MAJOR.$ANTIC_MINOR"
+         EXTRA_SHARED_FLAGS="-Wl,-soname,$ANTIC_LIB_SONAME"
          ANTIC_SOLIB=1;;
    esac
    EXTRA_SHARED_FLAGS="${EXTRA_SHARED_FLAGS} -Wl,-rpath,${GMP_LIB_DIR} -Wl,-rpath,${MPFR_LIB_DIR} -Wl,-rpath,${FLINT_LIB_DIR}"

--- a/setup.py
+++ b/setup.py
@@ -129,7 +129,7 @@ class NoBinaryBuild(build):
     Disables building binary wheels for this package.
 
     Since such binary wheels are not relocatable because we hard code library
-    paths into our hedaer files so cppyy known where things are located.
+    paths into our hedaer files so cppyy knows where things are located.
     """
 
     def run(self):


### PR DESCRIPTION
According to the docs at https://developer.apple.com/library/archive/documentation/DeveloperTools/Conceptual/DynamicLibraries/100-Articles/CreatingDynamicLibraries.html

> The major version number is specified in the library's filename as "A" in -o libratings.A.dylib.

Fixes #80.

---

But I guess the above documentation assumes that the major number enodes ABI backwards compatibility.